### PR TITLE
don't translate dates to UTC, create them as UTC

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -61,8 +61,8 @@ def extend_with_default(validator_class):
                 if subschema['format'] == 'date-time' and instance.get(property) is not None:
                     try:
                         instance[property] = datetime.fromtimestamp(
-                            rfc3339_to_timestamp(instance[property])
-                        ).replace(tzinfo=tz.tzutc())
+                            rfc3339_to_timestamp(instance[property]),
+                            tz=tz.tzutc())
                     except Exception as e:
                         raise Exception('Error parsing property {}, value {}'
                                         .format(property, instance[property]))


### PR DESCRIPTION
Transit doesn't support timestamps with timezones (there are two "point in time" types - either "timestamp (RFC 3339, no offset)" or "int msecs since 1970") - so the Stitch pipeline doesn't support timezones either.

Given this limitation, our preferred behavior is to never convert between timezones inside of Stitch libraries or services. Assume that the exact calendar/clock reading that we receive is what the user wants to see in their warehouse.  Previously, this application would convert a datetime to UTC, now it will just pretend that any datetime it receives is UTC (without doing any conversion) - which should also protect against any downstream code doing a conversion.