### PR TITLE
Check json schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='0.7.7',
+      version='0.7.8',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ setup(name='target-stitch',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['target_stitch'],
       install_requires=[
-          'jsonschema',
+          'jsonschema==2.6.0',
           'mock==2.0.0',
-          'singer-python>=0.2.1',
-          'stitchclient>=0.4.6',
+          'singer-python==1.5.0',
+          'stitchclient==0.4.6',
           'strict-rfc3339',
       ],
       entry_points='''


### PR DESCRIPTION
https://trello.com/c/Z2xN9eFc/1053-cid-100064-mvmt-watches-freshdesk-tap-errors

Had an issue in production caused by an obviously invalid json schema for tap-freshdesk. But the error message from the jsonschema library was less than helpful.

This branch adds an explicit validation check for json schemas, and it raises a descriptive error message:

```
  INFO target_log - Traceback (most recent call last):
  INFO target_log -   File "/opt/code/target-stitch/target_stitch/__init__.py", line 138, in persist_lines
  INFO target_log -     validator.check_schema(message.schema)
  INFO target_log -   File "/home/vagrant/.virtualenvs/orchestrator/lib/python3.4/site-packages/jsonschema-2.6.0-py3.4.egg/jsonschema/validators.py", line 83, in check_schema
  INFO target_log -     raise SchemaError.create_from(error)
  INFO target_log - jsonschema.exceptions.SchemaError: {'type': ['string']} is not of type 'string'
  INFO target_log -
  INFO target_log - Failed validating 'type' in schema['properties']['id']:
  INFO target_log -     {'format': 'uri', 'type': 'string'}
  INFO target_log -
  INFO target_log - On instance['id']:
  INFO target_log -     {'type': ['string']}
  INFO target_log -
  INFO target_log - The above exception was the direct cause of the following exception:
  INFO target_log -
  INFO target_log - Traceback (most recent call last):
  INFO target_log -   File "/home/vagrant/.virtualenvs/orchestrator/bin/target-stitch", line 11, in <module>
  INFO target_log -     load_entry_point('target-stitch', 'console_scripts', 'target-stitch')()
  INFO target_log -   File "/opt/code/target-stitch/target_stitch/__init__.py", line 218, in main
  INFO target_log -     state = persist_lines(client, input)
  INFO target_log -   File "/opt/code/target-stitch/target_stitch/__init__.py", line 140, in persist_lines
  INFO target_log -     raise Exception("Invalid json schema for stream {}: {}".format(message.stream, message.schema)) from schema_error
  INFO target_log - Exception: Invalid json schema for stream time_entries: {'id': {'type': ['string']}}
```