### PR TITLE
Validate that keys are present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='0.7.8',
+      version='0.7.9',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -132,6 +132,7 @@ def persist_lines(stitchclient, lines):
         elif isinstance(message, singer.SchemaMessage):
             schemas[message.stream] = message.schema
             key_properties[message.stream] = message.key_properties
+            schemas[message.stream]['required'] = key_properties[message.stream]
             validator = extend_with_default(Draft4Validator)
 
             try:

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -55,6 +55,23 @@ class TestTargetStitch(unittest.TestCase):
             with self.assertRaises(Exception):
                 target_stitch.persist_lines(client, message_lines(recs))
 
+    def test_persist_lines_fails_without_keys(self):
+        inputs = [
+            {"type": "SCHEMA",
+             "stream": "users",
+             "key_properties": ["id"],
+             "schema": {
+                 "properties": {
+                     "id": {"type": "integer"},
+                     "name": {"type": "string"}}}},
+            {"type": "RECORD",
+             "stream": "users",
+             "record": {"name": "Joshua"}}]
+
+        with DummyClient() as client:
+            with self.assertRaises(Exception):
+                target_stitch.persist_lines(client, message_lines(inputs))
+
     def test_persist_lines_sets_key_names(self):
         inputs = [
             {"type": "SCHEMA",


### PR DESCRIPTION
Fixes https://github.com/singer-io/target-stitch/issues/12. This branch leverages the `required` field of JSON Schema: https://spacetelescope.github.io/understanding-json-schema/reference/object.html#required

```
$ cat fixerio-invalid-no-keys.json | target-stitch -n
  INFO ---- DRY RUN: NOTHING IS BEING PERSISTED TO STITCH ----
  INFO Persisted batch of 1 records to Stitch
Traceback (most recent call last):
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 102, in parse_record
    validator.validate(o)
  File "/home/vagrant/.virtualenvs/target-stitch/lib/python3.4/site-packages/jsonschema-2.6.0-py3.4.egg/jsonschema/validators.py", line 130, in validate
    raise error
jsonschema.exceptions.ValidationError: 'date' is a required property

Failed validating 'required' in schema:
    {'additionalProperties': True,
     'properties': {'date': {'format': 'date-time', 'type': 'string'}},
     'required': ['date'],
     'type': 'object'}

On instance:
    {'AUD': 1.2963,
...
     'ZAR': 12.94}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/target-stitch/bin/target-stitch", line 11, in <module>
    load_entry_point('target-stitch', 'console_scripts', 'target-stitch')()
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 219, in main
    state = persist_lines(client, input)
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 125, in persist_lines
    'data': parse_record(message.stream, message.record, schemas, validators)}
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 104, in parse_record
    raise ValueError('Record does not conform to schema. Please see logs for details.') from exc
ValueError: Record does not conform to schema. Please see logs for details.
```