### PR TITLE
Raise a descriptive exception when missing a schema

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -113,8 +113,9 @@ def persist_lines(stitchclient, lines):
     key_properties = {}
     validators = {}
     for line in lines:
-
         message = singer.parse_message(line)
+        if message.stream not in key_properties:
+            raise Exception("Missing schema for {}".format(message.stream))
 
         if isinstance(message, singer.RecordMessage):
             stitch_message = {
@@ -185,7 +186,7 @@ def stitch_client(args):
         else:
             return Client(client_id, token, callback_function=write_last_state)
 
-        
+
 def collect():
     try:
         version = pkg_resources.get_distribution('target-stitch').version

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -114,10 +114,11 @@ def persist_lines(stitchclient, lines):
     validators = {}
     for line in lines:
         message = singer.parse_message(line)
-        if message.stream not in key_properties:
-            raise Exception("Missing schema for {}".format(message.stream))
 
         if isinstance(message, singer.RecordMessage):
+            if message.stream not in key_properties:
+                raise Exception("Missing schema for {}".format(message.stream))
+
             stitch_message = {
                 'action': 'upsert',
                 'table_name': message.stream,


### PR DESCRIPTION
Missing schemas would raise errors that looked like `KeyError: 'stream_name'`. Check for a missing schema before the KeyError occurs and raise an exception that describes the root cause.