### PR TITLE
Allow empty key properties

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -132,7 +132,11 @@ def persist_lines(stitchclient, lines):
         elif isinstance(message, singer.SchemaMessage):
             schemas[message.stream] = message.schema
             key_properties[message.stream] = message.key_properties
-            schemas[message.stream]['required'] = key_properties[message.stream]
+
+            # JSON schema will complain if 'required' is present but
+            # empty, so don't set it if there are no key properties
+            if message.key_properties:
+                schemas[message.stream]['required'] = message.key_properties
             validator = extend_with_default(Draft4Validator)
 
             try:

--- a/tests/empty_key_properties.json
+++ b/tests/empty_key_properties.json
@@ -1,0 +1,2 @@
+{"type": "SCHEMA", "stream": "test_empty_key_properties", "key_properties": [], "schema": {"type": "object", "properties": {"name": {"type": "string"}}}}
+{"type": "RECORD", "stream": "test_empty_key_properties", "record": {"name": "Mike"}}

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -39,6 +39,10 @@ schema = {"type": "SCHEMA",
           "schema": {"properties": {"i": {"type": "integer"}}}
 }
 
+def load_sample_lines(filename):
+    with open('tests/' + filename) as fp:
+        return [line for line in fp]
+
 
 class TestTargetStitch(unittest.TestCase):
 
@@ -54,6 +58,14 @@ class TestTargetStitch(unittest.TestCase):
         with DummyClient() as client:
             with self.assertRaises(Exception):
                 target_stitch.persist_lines(client, message_lines(recs))
+
+    def test_persist_lines_works_with_empty_key_properties(self):
+        lines = load_sample_lines('empty_key_properties.json')
+        with DummyClient() as client:
+            target_stitch.persist_lines(client, lines)
+            self.assertEqual(len(client.messages), 1)
+            self.assertEqual(client.messages[0]['key_names'], [])
+
 
     def test_persist_lines_fails_without_keys(self):
         inputs = [


### PR DESCRIPTION
The issue was that we were always adding a 'required' property onto the schema for the records, to make the properties listed as key_properties required. When there were no key properties, we were setting 'required' to an empty array, which apparently is not allowed in JSON-schema. I just changed it so we don't set 'required' if there are no key_properties.

Added a test to cover it and functional-tested by piping the 'empty_key_properties.json' file into target-stitch and confirming that it persisted the record to Stitch.