### PR TITLE
Add versioned streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='target-stitch',
       install_requires=[
           'jsonschema==2.6.0',
           'mock==2.0.0',
-          'singer-python==1.8.0',
+          'singer-python==1.8.1',
           'stitchclient==0.5.0',
           'strict-rfc3339',
       ],

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(name='target-stitch',
       install_requires=[
           'jsonschema==2.6.0',
           'mock==2.0.0',
-          'singer-python==1.5.0',
-          'stitchclient==0.4.6',
+          'singer-python==1.8.0',
+          'stitchclient==0.5.0',
           'strict-rfc3339',
       ],
       entry_points='''

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -127,8 +127,8 @@ def persist_lines(stitchclient, lines):
                 'data': parse_record(message.stream, message.record, schemas, validators)
             }
             if message.version is not None:
-                stitch_message['version'] = message.version
-            
+                stitch_message['table_version'] = message.version
+
             stitchclient.push(stitch_message, state)
             state = None
 
@@ -136,11 +136,12 @@ def persist_lines(stitchclient, lines):
             stitch_message = {
                 'action': 'switch_view',
                 'table_name': message.stream,
-                'version': message.version
+                'table_version': message.version,
+                'sequence': int(time.time() * 1000)
             }
             stitchclient.push(stitch_message, state)
             state = None
-            
+
         elif isinstance(message, singer.StateMessage):
             state = message.value
 

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -124,10 +124,23 @@ def persist_lines(stitchclient, lines):
                 'table_name': message.stream,
                 'key_names': key_properties[message.stream],
                 'sequence': int(time.time() * 1000),
-                'data': parse_record(message.stream, message.record, schemas, validators)}
+                'data': parse_record(message.stream, message.record, schemas, validators)
+            }
+            if message.version is not None:
+                stitch_message['version'] = message.version
+            
             stitchclient.push(stitch_message, state)
             state = None
 
+        elif isinstance(message, singer.ActivateVersionMessage):
+            stitch_message = {
+                'action': 'switch_view',
+                'table_name': message.stream,
+                'version': message.version
+            }
+            stitchclient.push(stitch_message, state)
+            state = None
+            
         elif isinstance(message, singer.StateMessage):
             state = message.value
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -252,3 +252,17 @@ class TestTargetStitch(unittest.TestCase):
         with DummyClient() as client:
             with self.assertRaises(Exception):
                 target_stitch.persist_lines(client, message_lines(inputs))
+
+    def test_versioned_stream(self):
+        lines = load_sample_lines('versioned_stream.json')
+        with DummyClient() as client:
+            target_stitch.persist_lines(client, lines)
+            messages = [(m['action'], m['version']) for m in client.messages]
+            self.assertEqual(messages,
+                             [('upsert', 1),
+                              ('upsert', 1),
+                              ('upsert', 1),
+                              ('switch_view', 1),
+                              ('upsert', 2),
+                              ('upsert', 2),
+                              ('switch_view', 2)])

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -257,7 +257,7 @@ class TestTargetStitch(unittest.TestCase):
         lines = load_sample_lines('versioned_stream.json')
         with DummyClient() as client:
             target_stitch.persist_lines(client, lines)
-            messages = [(m['action'], m['version']) for m in client.messages]
+            messages = [(m['action'], m['table_version']) for m in client.messages]
             self.assertEqual(messages,
                              [('upsert', 1),
                               ('upsert', 1),

--- a/tests/versioned_stream.json
+++ b/tests/versioned_stream.json
@@ -1,0 +1,8 @@
+{"type": "SCHEMA", "stream": "users", "key_properties": ["id"], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}}
+{"type": "RECORD", "stream": "users", "version": 1, "record": {"id": 1, "name": "Sam"}}
+{"type": "RECORD", "stream": "users", "version": 1, "record": {"id": 2, "name": "Pat"}}
+{"type": "RECORD", "stream": "users", "version": 1, "record": {"id": 3, "name": "Alex"}}
+{"type": "ACTIVATE_VERSION", "stream": "users", "version": 1}
+{"type": "RECORD", "stream": "users", "version": 2, "record": {"id": 1, "name": "Samantha"}}
+{"type": "RECORD", "stream": "users", "version": 2, "record": {"id": 2, "name": "Patrick"}}
+{"type": "ACTIVATE_VERSION", "stream": "users", "version": 2}


### PR DESCRIPTION
Support the "table_version" and "switch_view" features that Stitch provides.

Now we will allow a `version` field on a RECORD message, and translate that to the `table_version` field of the `upsert` action. We will also allow an `ACTIVATE_VERSION` message, and translate that to a `switch_view` message.

I added a unit test for it, and verified it by running the tap locally on the `versioned_stream.json` input.