### PR TITLE
support decimal fields

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -103,10 +103,10 @@ def parse_record(stream, record, schemas, validators):
     o = copy.deepcopy(record)
 
     for field_name in o:
-        field_schema = schema['properties'].get(field_name, None)
+        field_schema = schema['properties'].get(field_name)
         if not field_schema or o[field_name] is None:
             continue
-        multiple_of = field_schema.get('multipleOf', None)
+        multiple_of = field_schema.get('multipleOf')
         if multiple_of and abs(multiple_of) < 1:
             original_decimal_precision = decimal.getcontext().prec
             precision = len(str(multiple_of).split('.')[1])

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -13,6 +13,7 @@ import threading
 import http.client
 import urllib
 import pkg_resources
+import decimal
 
 from datetime import datetime
 from dateutil import tz
@@ -91,13 +92,34 @@ def extend_with_default(validator_class):
     return validators.extend(validator_class, {"properties": set_defaults})
 
 
+ExtendedDraft4Validator = extend_with_default(Draft4Validator)
+
+
 def parse_record(stream, record, schemas, validators):
     if stream in schemas:
         schema = schemas[stream]
     else:
         schema = {}
     o = copy.deepcopy(record)
+
+    for field_name in o:
+        field_schema = schema['properties'].get(field_name, None)
+        if not field_schema or o[field_name] is None:
+            continue
+        multiple_of = field_schema.get('multipleOf', None)
+        if multiple_of and multiple_of < 1:
+            original_decimal_precision = decimal.getcontext().prec
+            precision = len(str(multiple_of).split('.')[1])
+            decimal.getcontext().prec = precision
+            o[field_name] = decimal.Decimal(format(o[field_name], '.' + str(precision) + 'f'))
+            # schema validator for `multipleOf` requires both the value under test and the
+            # `multipleOf` value to be of the same type (in this case, Decimal)
+            schema['properties'][field_name]['multipleOf'] = decimal.Decimal(str(multiple_of))
+            validators[stream] = ExtendedDraft4Validator(schema, format_checker=FormatChecker())
+            decimal.getcontext().prec = original_decimal_precision
+
     validator = validators[stream]
+
     try:
         validator.validate(o)
     except ValidationError as exc:
@@ -153,14 +175,13 @@ def persist_lines(stitchclient, lines):
             # empty, so don't set it if there are no key properties
             if message.key_properties:
                 schemas[message.stream]['required'] = message.key_properties
-            validator = extend_with_default(Draft4Validator)
 
             try:
-                validator.check_schema(message.schema)
+                ExtendedDraft4Validator.check_schema(message.schema)
             except SchemaError as schema_error:
                 raise Exception("Invalid json schema for stream {}: {}".format(message.stream, message.schema)) from schema_error
 
-            validators[message.stream] = validator(message.schema, format_checker=FormatChecker())
+            validators[message.stream] = ExtendedDraft4Validator(message.schema, format_checker=FormatChecker())
 
         else:
             raise Exception("Unrecognized message {} parsed from line {}".format(message, line))

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -114,7 +114,7 @@ def parse_record(stream, record, schemas, validators):
             o[field_name] = decimal.Decimal(format(o[field_name], '.' + str(precision) + 'f'))
             # schema validator for `multipleOf` requires both the value under test and the
             # `multipleOf` value to be of the same type (in this case, Decimal)
-            if type(schema['properties'][field_name]['multipleOf']) != decimal.Decimal:
+            if type(multiple_of) != decimal.Decimal:
                 schema['properties'][field_name]['multipleOf'] = decimal.Decimal(str(multiple_of))
                 validators[stream] = ExtendedDraft4Validator(schema, format_checker=FormatChecker())
             decimal.getcontext().prec = original_decimal_precision

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -114,8 +114,9 @@ def parse_record(stream, record, schemas, validators):
             o[field_name] = decimal.Decimal(format(o[field_name], '.' + str(precision) + 'f'))
             # schema validator for `multipleOf` requires both the value under test and the
             # `multipleOf` value to be of the same type (in this case, Decimal)
-            schema['properties'][field_name]['multipleOf'] = decimal.Decimal(str(multiple_of))
-            validators[stream] = ExtendedDraft4Validator(schema, format_checker=FormatChecker())
+            if type(schema['properties'][field_name]['multipleOf']) != decimal.Decimal:
+                schema['properties'][field_name]['multipleOf'] = decimal.Decimal(str(multiple_of))
+                validators[stream] = ExtendedDraft4Validator(schema, format_checker=FormatChecker())
             decimal.getcontext().prec = original_decimal_precision
 
     validator = validators[stream]

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -107,7 +107,7 @@ def parse_record(stream, record, schemas, validators):
         if not field_schema or o[field_name] is None:
             continue
         multiple_of = field_schema.get('multipleOf', None)
-        if multiple_of and multiple_of < 1:
+        if multiple_of and abs(multiple_of) < 1:
             original_decimal_precision = decimal.getcontext().prec
             precision = len(str(multiple_of).split('.')[1])
             decimal.getcontext().prec = precision


### PR DESCRIPTION
This change gives `target-stitch` the ability to properly recognize and handle decimal numerics and to persist those values to the Stitch Import API via [Transit](https://github.com/cognitect/transit-format#ground-and-extension-types)'s arbitrary precision decimal type. Such an ability is desirable, because it communicates precision and typing information that would be lost if floats alone were used to send non-integer numerics.

Here, we take advantage of [JSON Schema](https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json#L60)'s `multipleOf` field property to transmit the desirable precision information. A record with a schema like the following:

```python
[{"type": "SCHEMA",
  "stream": "testing",
  "key_properties": ["a_float", "a_dec"],
  "schema": {
      "properties": {
          "a_float": {"type": ["null", "number"]},
          "a_dec": {"type": ["null", "number"],
                    "multipleOf": 0.0001}}}},
{"type": "RECORD",
 "stream": "testing",
 "record": {"a_float": 4.72, "a_dec": 4.72}}]
```

will now be parsed with the schema information taken into account. The field with the `multipleOf` property is internally represented as a Decimal:

```python
{'a_float': 4.72, 'a_dec': Decimal('4.7200')}
```

And Transit handles this representation appropriately:

```python
>>> from transit.writer import Writer
>>> import decimal
>>> io = StringIO()
>>> writer = Writer(io, "json")
>>> writer.write(["a_float", 4.72])
>>> writer.write(["a_dec", decimal.Decimal('4.7200')])
>>> io.getvalue()
'["a_float",4.72],["a_dec","~f4.7200"]'
```
