### PR TITLE
Correct datetime handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='target-stitch',
           'singer-python==2.1.4',
           'stitchclient==0.5.0',
           'strict-rfc3339',
+          'python-dateutil==2.6.1',
       ],
       entry_points='''
           [console_scripts]

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import pdb
 import argparse
 import logging
 import logging.config
@@ -17,6 +17,7 @@ import decimal
 
 from datetime import datetime
 from dateutil import tz
+import dateutil
 
 from strict_rfc3339 import rfc3339_to_timestamp
 
@@ -107,9 +108,7 @@ def extend_with_default(validator_class):
             if "format" in subschema:
                 if subschema['format'] == 'date-time' and instance.get(property) is not None:
                     try:
-                        instance[property] = datetime.utcfromtimestamp(
-                            rfc3339_to_timestamp(instance[property])
-                        ).replace(tzinfo=tz.tzutc())
+                        instance[property] = dateutil.parser.parse(instance[property])
                     except Exception as e:
                         raise Exception('Error parsing property {}, value {}'
                                         .format(property, instance[property]))

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -5,7 +5,10 @@ import io
 import mock
 import sys
 import datetime
+import dateutil
 import jsonschema
+from strict_rfc3339 import rfc3339_to_timestamp
+from dateutil import tz
 
 class DummyClient(target_stitch.DryRunClient):
 
@@ -119,6 +122,21 @@ class TestTargetStitch(unittest.TestCase):
             target_stitch.persist_lines(client, message_lines(inputs))
             dt = client.messages[0]['data']['t']
             self.assertEqual(datetime.datetime, type(dt))
+
+    def test_poo(self):
+        def old_parse(s):
+            return datetime.datetime.utcfromtimestamp(rfc3339_to_timestamp(s)).replace(tzinfo=tz.tzutc())
+        def new_parse(s):
+            return dateutil.parser.parse(s)
+        dt = '2017-02-27T00:00:00+00:00'
+        self.assertEqual(old_parse(dt),
+                         new_parse(dt))
+
+        dt = '2017-02-27T00:00:00+04:00'
+        self.assertEqual(old_parse(dt),
+                         new_parse(dt))
+
+
 
     def test_persist_lines_fails_if_doesnt_fit_schema(self):
         inputs = [

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -123,20 +123,18 @@ class TestTargetStitch(unittest.TestCase):
             dt = client.messages[0]['data']['t']
             self.assertEqual(datetime.datetime, type(dt))
 
-    def test_poo(self):
-        def old_parse(s):
-            return datetime.datetime.utcfromtimestamp(rfc3339_to_timestamp(s)).replace(tzinfo=tz.tzutc())
-        def new_parse(s):
-            return dateutil.parser.parse(s)
-        dt = '2017-02-27T00:00:00+00:00'
-        self.assertEqual(old_parse(dt),
-                         new_parse(dt))
+    def test_timezones_and_milliseconds(self):
+        self.assertEqual(dateutil.parser.parse('2017-02-27T00:00:00+00:00'),
+                         datetime.datetime(2017, 2, 27, 0, 0, tzinfo=dateutil.tz.tzutc()))
 
-        dt = '2017-02-27T00:00:00+04:00'
-        self.assertEqual(old_parse(dt),
-                         new_parse(dt))
+        # milliseconds are preserved
+        self.assertEqual(dateutil.parser.parse('2017-02-27T00:00:00.001+00:00'),
+                         datetime.datetime(2017, 2, 27, 0, 0, 0, 1000, tzinfo=dateutil.tz.tzutc()))
 
-
+        # timezone is preserved
+        four_hours_in_seconds = 4 * 60 * 60
+        self.assertEqual(dateutil.parser.parse('2017-02-27T00:00:00+04:00'),
+                         datetime.datetime(2017, 2, 27, 0, 0, tzinfo=dateutil.tz.tzoffset(None, four_hours_in_seconds)))
 
     def test_persist_lines_fails_if_doesnt_fit_schema(self):
         inputs = [


### PR DESCRIPTION
### Pair
- @psantacl 
- @karstendick

The old code to handle datetimes preserved timezones but not milliseconds. The new code preserves both timezones and milliseconds.

```python
# old, wrong way to handle datetimes, which dropped a millisecond
>>> datetime.datetime.utcfromtimestamp(rfc3339_to_timestamp('2017-02-27T00:00:00.001+00:00')).replace(tzinfo=tz.tzutc())
datetime.datetime(2017, 2, 27, 0, 0, 0, 999, tzinfo=tzutc())
# new way to handle datetimes, which preserves milliseconds
>>> dateutil.parser.parse('2017-02-27T00:00:00.001+00:00')
datetime.datetime(2017, 2, 27, 0, 0, 0, 1000, tzinfo=tzutc())
```