### PR TITLE
Rewrite type handling

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -1,4 +1,31 @@
 #!/usr/bin/env python3
+
+# Changes target-stitch makes to schema and record
+# ================================================
+#
+# We have to make several changes to both the schema and the record in
+# order to correctly transform datatypes from the JSON input to the
+# Transit output and in order to take advantage of JSON Schema validation.
+#
+# 1. We walk the schema and look for instances of `"multipleOf": x` where
+# x is a float. For those cases, we convert x to a Decimal. We do this
+# because in the validation step below, both multipleOf and the value need
+# to be Decimal.
+#
+# 2. We walk each record along with its schema and look for cases where
+# the schema says `"multipleOf": x` and the value in the record is a
+# float.
+#
+# 3. We then validate the record against the schema using the jsonschema library.
+#
+# 4. After validation, we walk the record and the schema again looking for
+# nodes with type string and format date-time. We convert all such values
+# to datetime. We need to do this _after_ validation because validation
+# operates on strings, not datetime objects.
+
+
+
+
 import argparse
 import copy
 from datetime import datetime

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -44,7 +44,7 @@ def ensure_multipleof_is_decimal(schema):
         schema[SchemaKey.multipleOf] = float_to_decimal(schema[SchemaKey.multipleOf])
 
     if SchemaKey.properties in schema:
-        for k, v in schema[SchemaKey.properties]:
+        for k, v in schema[SchemaKey.properties].items():
             ensure_multipleof_is_decimal(v)
 
     if SchemaKey.items in schema:

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -38,6 +38,7 @@ class SchemaKey:
     properties = 'properties'
     items = 'items'
 
+
 def ensure_multipleof_is_decimal(schema):
 
     if SchemaKey.multipleOf in schema:
@@ -50,6 +51,27 @@ def ensure_multipleof_is_decimal(schema):
     if SchemaKey.items in schema:
         ensure_multipleof_is_decimal(schema[SchemaKey.items])
 
+
+def convert_floats_to_decimals(schema, data):
+
+    if SchemaKey.properties in schema and isinstance(data, dict):
+        for key, subschema in schema[SchemaKey.properties].items():
+            if key in data:
+                data[key] = convert_floats_to_decimals(subschema, data[key])
+        return data
+
+    if SchemaKey.items in schema and isinstance(data, list):
+        subschema = schema[SchemaKey.items]
+        for i in range(len(data)):
+            data[i] = convert_floats_to_decimals(subschema, data[i])
+        return data
+    
+    if SchemaKey.multipleOf in schema and isinstance(data, float):
+        return float_to_decimal(data)
+
+    return data
+
+        
 def write_last_state(states):
     logger.info('Persisted batch of {} records to Stitch'.format(len(states)))
     last_state = None

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -53,6 +53,8 @@ def ensure_multipleof_is_decimal(schema):
     Recursively walks the given schema (which must be dict), converting
     every instance of the multipleOf keyword to a Decimal.
 
+    This modifies the input schema and also returns it.
+
     '''
     if SchemaKey.multipleOf in schema:
         schema[SchemaKey.multipleOf] = float_to_decimal(schema[SchemaKey.multipleOf])
@@ -63,6 +65,7 @@ def ensure_multipleof_is_decimal(schema):
 
     if SchemaKey.items in schema:
         ensure_multipleof_is_decimal(schema[SchemaKey.items])
+
     return schema
 
 def convert_floats_to_decimals(schema, data):
@@ -72,6 +75,7 @@ def convert_floats_to_decimals(schema, data):
     the schema is "number" and there is a "multipleOf" specified and the
     value is a float, converts the value to a Decimal.
 
+    This modifies the input data and also returns it.
     '''
     if schema is None:
         return data
@@ -102,6 +106,7 @@ def convert_datetime_strings_to_datetime(schema, data):
     dateutil.parser.parse. We use that parser because it correctly handles
     the date-time formats required by JSON Schema.
 
+    This modifies the input data and also returns it.
     '''
     if schema is None:
         return data

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -136,7 +136,7 @@ def parse_record(stream, record, schemas, validators):
             original_decimal_precision = decimal.getcontext().prec
             precision = len(str(multiple_of).split('.')[1])
             decimal.getcontext().prec = precision
-            o[field_name] = decimal.Decimal(format(o[field_name], '.' + str(precision) + 'f'))
+            o[field_name] = decimal.Decimal(str(format(o[field_name], '.' + str(precision) + 'f')))
             # schema validator for `multipleOf` requires both the value under test and the
             # `multipleOf` value to be of the same type (in this case, Decimal)
             if type(multiple_of) != decimal.Decimal:

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -1,24 +1,22 @@
 #!/usr/bin/env python3
-import pdb
 import argparse
-import decimal
+import copy
+from datetime import datetime
 from decimal import Decimal
+import http.client
+import io
+import json
 import logging
 import logging.config
 import os
-import copy
-import io
+import pdb
 import sys
-import time
-import json
 import threading
-import http.client
+import time
 import urllib
+
 import pkg_resources
 
-
-from datetime import datetime
-from dateutil import tz
 import dateutil
 
 from strict_rfc3339 import rfc3339_to_timestamp
@@ -147,7 +145,7 @@ class TransitDumper(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
             return obj.isoformat()
-        if isinstance(obj, decimal.Decimal):
+        if isinstance(obj, Decimal):
             # wanted a simple yield str(o) in the next line,
             # but that would mean a yield on the line with super(...),
             # which wouldn't work (see my comment below), so...

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -357,3 +357,38 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
             schema,
             {'multipleOf': Decimal('0.01')})
         
+    def test_recursive_properties(self):
+        schema = {
+            'properties': {
+                'child': {
+                    'multipleOf': 0.01
+                }
+            }
+        }
+        target_stitch.ensure_multipleof_is_decimal(schema)        
+        self.assertEqual(
+            schema,
+            {
+                'properties': {
+                    'child': {
+                        'multipleOf': Decimal('0.01')
+                    }
+                }
+            }
+        )
+        
+    def test_recursive_properties(self):
+        schema = {
+            'items': {
+                'multipleOf': 0.01
+            }
+        }
+        target_stitch.ensure_multipleof_is_decimal(schema)        
+        self.assertEqual(
+            schema,
+            {
+                'items': {
+                    'multipleOf': Decimal('0.01')
+                }
+            })
+        

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -392,3 +392,56 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
                 }
             })
         
+
+class TestConvertFloatsToDecimals(unittest.TestCase):
+
+    def test_simple(self):
+        self.assertEqual(
+            target_stitch.convert_floats_to_decimals(
+                {'multipleOf': Decimal('0.01')},
+                1.23),
+            Decimal('1.23'))
+
+    def test_simple_string(self):
+        self.assertEqual(
+            target_stitch.convert_floats_to_decimals(
+                {'multipleOf': Decimal('0.01')},
+                '1.23'),
+            '1.23')
+
+    def test_recursive_properties_convert(self):
+        schema = {
+            'properties': {
+                'child': {
+                    'multipleOf': 0.01
+                }
+            }
+        }
+        record = {'child': 1.23}
+        self.assertEqual(
+            target_stitch.convert_floats_to_decimals(schema, record),
+            {'child': Decimal('1.23')})
+
+    def test_recursive_properties_empty(self):
+        schema = {
+            'properties': {
+                'child': {
+                    'multipleOf': 0.01
+                }
+            }
+        }
+        record = 'hello'
+        self.assertEqual(
+            target_stitch.convert_floats_to_decimals(schema, record),
+            record)
+
+    def test_recursive_items_convert(self):
+        schema = {
+            'items': {
+                'multipleOf': 0.01
+            }
+        }
+        record = [1.23, 'hi', None]
+        self.assertEqual(
+            target_stitch.convert_floats_to_decimals(schema, record),
+            [Decimal('1.23'), 'hi', None])

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -372,6 +372,13 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
         self.assertEqual(
             schema,
             {'multipleOf': Decimal('0.01')})
+
+    def test_simple_int(self):
+        schema = {'multipleOf': 1}
+        target_stitch.ensure_multipleof_is_decimal(schema)        
+        self.assertEqual(
+            schema,
+            {'multipleOf': Decimal('1')})        
         
     def test_recursive_properties(self):
         schema = {
@@ -411,16 +418,23 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
 
 class TestConvertFloatsToDecimals(unittest.TestCase):
 
-    def test_simple(self):
+    def test_simple_float(self):
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(
+            target_stitch.convert_numbers_to_decimals(
                 {'multipleOf': Decimal('0.01')},
                 1.23),
             Decimal('1.23'))
 
+    def test_simple_int(self):
+        self.assertEqual(
+            type(target_stitch.convert_numbers_to_decimals(
+                {'multipleOf': Decimal('0.01')},
+                1)),
+            Decimal)
+
     def test_simple_string(self):
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(
+            target_stitch.convert_numbers_to_decimals(
                 {'multipleOf': Decimal('0.01')},
                 '1.23'),
             '1.23')
@@ -435,7 +449,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = {'child': 1.23}
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             {'child': Decimal('1.23')})
 
     def test_recursive_properties_empty(self):
@@ -448,7 +462,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = 'hello'
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             record)
 
     def test_recursive_items_convert(self):
@@ -459,7 +473,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = [1.23, 'hi', None]
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             [Decimal('1.23'), 'hi', None])
 
 class TestConvertDatetimeStringsToDatetimes(unittest.TestCase):

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -461,3 +461,35 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         self.assertEqual(
             target_stitch.convert_floats_to_decimals(schema, record),
             [Decimal('1.23'), 'hi', None])
+
+class TestConvertDatetimeStringsToDatetimes(unittest.TestCase):
+
+    input_datetime_string = '2017-02-27T00:00:00+04:00'
+    expected_datetime = datetime.datetime(2017, 2, 27, 0, 0, tzinfo=dateutil.tz.tzoffset(None, 4 * 60 * 60))
+    
+    def test_simple(self):
+        self.assertEqual(
+            target_stitch.convert_datetime_strings_to_datetime(
+                {'format': 'date-time'},
+                self.input_datetime_string),
+            self.expected_datetime)
+
+    def test_simple_non_string(self):
+        self.assertEqual(
+            target_stitch.convert_datetime_strings_to_datetime(
+                {'format': 'date-time'},
+                Decimal('1.23')),
+            Decimal('1.23'))
+
+    def test_recursive_properties_convert(self):
+        schema = {
+            'properties': {
+                'child': {
+                    'format': 'date-time'
+                }
+            }
+        }
+        record = {'child': self.input_datetime_string}
+        self.assertEqual(
+            target_stitch.convert_datetime_strings_to_datetime(schema, record),
+            {'child': self.expected_datetime})

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -133,48 +133,48 @@ class TestTargetStitch(unittest.TestCase):
                      "decimal": {"type": "number", "multipleOf": 0.01}}}},
             {"type": "RECORD",
              "stream": "users",
-             "record": {"id": 1, "decimal": 1234.1234}}]
+             "record": {"id": 1, "decimal": 1234.12}}]
 
         with DummyClient() as client:
             target_stitch.persist_lines(client, message_lines(inputs))
             dec = client.messages[0]['data']['decimal']
             self.assertEqual(decimal.Decimal, type(dec))
 
-    # def test_persist_lines_converts_deep_decimal(self):
-    #     schema = {
-    #         "type": "SCHEMA",
-    #         "stream": "users",
-    #         "key_properties": ["id"],
-    #         "schema": {
-    #             "properties": {
-    #                 "id": {"type": "integer"},
-    #                 "child": {
-    #                     "type": "object",
-    #                     "properties": {
-    #                         "decimal": {
-    #                             "type": "number",
-    #                             "multipleOf": Decimal('0.01')
-    #                         }
-    #                     }
-    #                 }
-    #             }
-    #         }
-    #     }
-    #     record = {
-    #         "type": "RECORD",
-    #         "stream": "users",
-    #         "record": {
-    #             "id": 1,
-    #             "child": {
-    #                 "decimal": Decimal('1234.12')
-    #             }
-    #         }
-    #     }
+    def test_persist_lines_converts_deep_decimal(self):
+        schema = {
+            "type": "SCHEMA",
+            "stream": "users",
+            "key_properties": ["id"],
+            "schema": {
+                "properties": {
+                    "id": {"type": "integer"},
+                    "child": {
+                        "type": "object",
+                        "properties": {
+                            "decimal": {
+                                "type": "number",
+                                "multipleOf": 0.01
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        record = {
+            "type": "RECORD",
+            "stream": "users",
+            "record": {
+                "id": 1,
+                "child": {
+                    "decimal": 1234.12
+                }
+            }
+        }
 
-    #     with DummyClient() as client:
-    #         target_stitch.persist_lines(client, message_lines([schema, record]))
-    #         dec = client.messages[0]['data']['child']['decimal']
-    #         self.assertEqual(decimal.Decimal, type(dec))
+        with DummyClient() as client:
+            target_stitch.persist_lines(client, message_lines([schema, record]))
+            dec = client.messages[0]['data']['child']['decimal']
+            self.assertEqual(decimal.Decimal, type(dec))
 
             
     def test_persist_lines_fails_if_doesnt_fit_schema(self):
@@ -344,7 +344,7 @@ class TestTargetStitch(unittest.TestCase):
         with DummyClient() as client:
             target_stitch.persist_lines(client, message_lines(inputs))
             self.assertEqual(str(sorted(client.messages[0]['data'].items())),
-                             "[('a_dec', Decimal('4.7200')), ('a_float', 4.72)]")
+                             "[('a_dec', Decimal('4.72')), ('a_float', 4.72)]")
             self.assertEqual(str(sorted(client.messages[1]['data'].items())),
                              "[('a_dec', None), ('a_float', 4.72)]")
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -7,6 +7,7 @@ import sys
 import datetime
 import jsonschema
 import decimal
+from decimal import Decimal
 
 class DummyClient(target_stitch.DryRunClient):
 
@@ -139,41 +140,41 @@ class TestTargetStitch(unittest.TestCase):
             dec = client.messages[0]['data']['decimal']
             self.assertEqual(decimal.Decimal, type(dec))
 
-    def test_persist_lines_converts_deep_decimal(self):
-        schema = {
-            "type": "SCHEMA",
-            "stream": "users",
-            "key_properties": ["id"],
-            "schema": {
-                "properties": {
-                    "id": {"type": "integer"},
-                    "child": {
-                        "type": "object",
-                        "properties": {
-                            "decimal": {
-                                "type": "number",
-                                "multipleOf": Decimal('0.01')
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        record = {
-            "type": "RECORD",
-            "stream": "users",
-            "record": {
-                "id": 1,
-                "child": {
-                    "decimal": Decimal('1234.12')
-                }
-            }
-        }
+    # def test_persist_lines_converts_deep_decimal(self):
+    #     schema = {
+    #         "type": "SCHEMA",
+    #         "stream": "users",
+    #         "key_properties": ["id"],
+    #         "schema": {
+    #             "properties": {
+    #                 "id": {"type": "integer"},
+    #                 "child": {
+    #                     "type": "object",
+    #                     "properties": {
+    #                         "decimal": {
+    #                             "type": "number",
+    #                             "multipleOf": Decimal('0.01')
+    #                         }
+    #                     }
+    #                 }
+    #             }
+    #         }
+    #     }
+    #     record = {
+    #         "type": "RECORD",
+    #         "stream": "users",
+    #         "record": {
+    #             "id": 1,
+    #             "child": {
+    #                 "decimal": Decimal('1234.12')
+    #             }
+    #         }
+    #     }
 
-        with DummyClient() as client:
-            target_stitch.persist_lines(client, message_lines([schema, record]))
-            dec = client.messages[0]['data']['child']['decimal']
-            self.assertEqual(decimal.Decimal, type(dec))
+    #     with DummyClient() as client:
+    #         target_stitch.persist_lines(client, message_lines([schema, record]))
+    #         dec = client.messages[0]['data']['child']['decimal']
+    #         self.assertEqual(decimal.Decimal, type(dec))
 
             
     def test_persist_lines_fails_if_doesnt_fit_schema(self):
@@ -346,3 +347,13 @@ class TestTargetStitch(unittest.TestCase):
                              "[('a_dec', Decimal('4.7200')), ('a_float', 4.72)]")
             self.assertEqual(str(sorted(client.messages[1]['data'].items())),
                              "[('a_dec', None), ('a_float', 4.72)]")
+
+
+class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
+    def test_simple(self):
+        schema = {'multipleOf': 0.01}
+        target_stitch.ensure_multipleof_is_decimal(schema)        
+        self.assertEqual(
+            schema,
+            {'multipleOf': Decimal('0.01')})
+        


### PR DESCRIPTION
Change target-stitch so that it converts float values to decimals where the schema specifies multipleOf.

We also decided to rewrite the way that we're doing datetime conversion. We were doing it as part of schema validation by exending `Draft4Validator`. Kyle suggested that that's actually inappropriate and we should be doing it as a separate step. I agreed. The validator seems like it's not really designed to do conversion, just validation, and our conversion code was sort of shimmed into the default handler.

I am somewhat concerned this might hurt performance, but I doubt it will be an issue for most taps that hit HTTP APIs. I'm more concerned about cases where we think target-stitch might be the bottleneck, such as tap-mysql. If profiling indicates that the type conversion is a bottleneck, we can probably speed it up by changing `convert_floats_to_decimals` and `convert_datetime_strings_to_datetime` so that they operate on a pruned down version of the schema, to avoid iterating over paths that we will never need to convert.

Testing

* Added unit tests to cover new behavior
* Ran script in connection service to compare output (in Redshift) of old sourcerer integration and current Facebook tap piped to this version of target-stitch. All differences were explainable. Columns that were DOUBLE now are DECIMAL.
* Ran tap-tester against both hubspot scenarios and tests pass.