### PR TITLE
Convert ints to decimals

### DIFF
--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -372,6 +372,13 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
         self.assertEqual(
             schema,
             {'multipleOf': Decimal('0.01')})
+
+    def test_simple_int(self):
+        schema = {'multipleOf': 1}
+        target_stitch.ensure_multipleof_is_decimal(schema)        
+        self.assertEqual(
+            schema,
+            {'multipleOf': Decimal('1')})        
         
     def test_recursive_properties(self):
         schema = {
@@ -411,16 +418,23 @@ class TestEnsureMultipleOfIsDecimal(unittest.TestCase):
 
 class TestConvertFloatsToDecimals(unittest.TestCase):
 
-    def test_simple(self):
+    def test_simple_float(self):
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(
+            target_stitch.convert_numbers_to_decimals(
                 {'multipleOf': Decimal('0.01')},
                 1.23),
             Decimal('1.23'))
 
+    def test_simple_int(self):
+        self.assertEqual(
+            type(target_stitch.convert_numbers_to_decimals(
+                {'multipleOf': Decimal('0.01')},
+                1)),
+            Decimal)
+
     def test_simple_string(self):
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(
+            target_stitch.convert_numbers_to_decimals(
                 {'multipleOf': Decimal('0.01')},
                 '1.23'),
             '1.23')
@@ -435,7 +449,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = {'child': 1.23}
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             {'child': Decimal('1.23')})
 
     def test_recursive_properties_empty(self):
@@ -448,7 +462,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = 'hello'
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             record)
 
     def test_recursive_items_convert(self):
@@ -459,7 +473,7 @@ class TestConvertFloatsToDecimals(unittest.TestCase):
         }
         record = [1.23, 'hi', None]
         self.assertEqual(
-            target_stitch.convert_floats_to_decimals(schema, record),
+            target_stitch.convert_numbers_to_decimals(schema, record),
             [Decimal('1.23'), 'hi', None])
 
 class TestConvertDatetimeStringsToDatetimes(unittest.TestCase):


### PR DESCRIPTION
In addition to converting float values to Decimal when `multipleOf` is specified in the schema, we also need to convert int values to Decimal. The only important change here is this: https://github.com/singer-io/target-stitch/pull/25/files#diff-5f4b3e9a2d5a9eba46ac89391c8e0c0fR119. The rest is just changing names and wording.

Added a test to assert that an int becomes a Decimal when `multipleOf` is present in the schema. Test was initially broken, and this change fixed it.