### PR TITLE
Replace /push with /batch

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -11,6 +11,7 @@ import http.client
 import io
 import json
 import os
+import re
 import sys
 import threading
 import time
@@ -272,6 +273,13 @@ def collect():
         LOGGER.debug('Collection request failed')
 
 
+def use_batch_url(url):
+    result = url
+    if url.endswith('/import/push'):
+        result = url.replace('/import/push', '/import/batch')
+        LOGGER.info("I can't hit Stitch's /push endpoint, using /batch endpoint instead. Changed %s to %s", url, result)
+    return result
+
 def main():
     '''Main entry point'''
     parser = argparse.ArgumentParser()
@@ -302,7 +310,7 @@ def main():
         config = json.load(args.config)
         token = config.get('token')
         stitch_url = config.get('stitch_url', DEFAULT_STITCH_URL)
-
+        
         if not token:
             raise Exception('Configuration is missing required "token" field')
 

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -274,10 +274,12 @@ def collect():
 
 
 def use_batch_url(url):
+    '''Replace /import/push with /import/batch in URL'''
     result = url
     if url.endswith('/import/push'):
         result = url.replace('/import/push', '/import/batch')
-        LOGGER.info("I can't hit Stitch's /push endpoint, using /batch endpoint instead. Changed %s to %s", url, result)
+        LOGGER.info("I can't hit Stitch's /push endpoint, using " +
+                    "/batch endpoint instead. Changed %s to %s", url, result)
     return result
 
 def main():
@@ -309,8 +311,8 @@ def main():
     else:
         config = json.load(args.config)
         token = config.get('token')
-        stitch_url = config.get('stitch_url', DEFAULT_STITCH_URL)
-        
+        stitch_url = use_batch_url(config.get('stitch_url', DEFAULT_STITCH_URL))
+
         if not token:
             raise Exception('Configuration is missing required "token" field')
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -282,3 +282,11 @@ class TestSerialize(unittest.TestCase):
         self.assertEqual(expected, self.unpack_colors(self.serialize_with_limit(1000)))
         self.assertEqual(expected, self.unpack_colors(self.serialize_with_limit(500)))
         self.assertEqual(expected, self.unpack_colors(self.serialize_with_limit(300)))
+
+class test_use_batch_url(unittest.TestCase):
+
+    push_url = 'https://api.stitchdata.com/v2/import/push'
+    batch_url = 'https://api.stitchdata.com/v2/import/batch'
+    
+    def test_change(self):
+        self.assertEqual(self.batch_url, target_stitch.use_batch_url(self.push_url))


### PR DESCRIPTION
The new version of target-stitch can only hit the /batch endpoint, not the /push endpoint. This makes it so if we're called with a URL that ends with /import/push we'll replace it with /import/batch.