### PR TITLE
Stdin reader thread

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -184,7 +184,10 @@ class StdinReader(Thread):
         '''Read all the input from my reader and put each line on the queue.
 
         Puts None on the queue when finished to indicate there's no more
-        data. Exits if we get an Exception while reading from stdin.
+        data. Exits if we get an Exception while reading from stdin. If we
+        get an error reading input, we want to be absolutely sure we turn
+        that into an error exit status, and the simplest way to do that in
+        a multi-threaded environment is to exit immediately.
 
         '''
         try:

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -283,6 +283,6 @@ class test_use_batch_url(unittest.TestCase):
 
     push_url = 'https://api.stitchdata.com/v2/import/push'
     batch_url = 'https://api.stitchdata.com/v2/import/batch'
-    
+
     def test_change(self):
         self.assertEqual(self.batch_url, target_stitch.use_batch_url(self.push_url))


### PR DESCRIPTION
Use a separate thread to read from stdin and put the input lines on a buffered queue. This allows the tap producing the data to continue to work while we're paused writing to the Gate.