### PR TITLE
Add timings

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -38,7 +38,7 @@ StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties'])
 DEFAULT_STITCH_URL = 'https://api.stitchdata.com/v2/import/batch'
 
 class Timings(object):
-
+    '''Gathers timing information for the three main steps of the Tap.'''
     def __init__(self):
         self.last_time = time.time()
         self.timings = {
@@ -50,6 +50,9 @@ class Timings(object):
 
     @contextmanager
     def mode(self, mode):
+        '''We wrap the big steps of the Tap in this context manager to accumulate
+        timing info.'''
+
         start = time.time()
         yield
         end = time.time()
@@ -59,7 +62,7 @@ class Timings(object):
 
 
     def log_timings(self):
-
+        '''We call this with every flush to print out the accumulated timings'''
         LOGGER.info('Timings: unspecified: %.3f; reading: %.3f; serializing: %.3f; posting: %.3f;',
                     self.timings[None],
                     self.timings['reading'],


### PR DESCRIPTION
Periodically print out how long we've spent in each of the following steps of the tap:

* Reading input (blocked calling get from queue)
* Serializing request bodies
* Executing a POST
* Other unspecified time

I wanted to add this so we have an easy way of telling whether one of those steps is taking unexpectedly long in production. So far on my VM the timings are what I would expect. POSTing to the gate dominates the running time by far, followed by serializing requests, followed by unspecified time, followed by blocked reading input.