### PR TITLE
only check for missing keys when key_names is defined

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -164,11 +164,12 @@ class ValidatingHandler(object): # pylint: disable=too-few-public-methods
             if isinstance(message, singer.RecordMessage):
                 data = float_to_decimal(message.record)
                 validator.validate(data)
-                for k in key_names:
-                    if k not in data:
-                        raise TargetStitchException(
-                            'Message {} is missing key property {}'.format(
-                                i, k))
+                if key_names:
+                    for k in key_names:
+                        if k not in data:
+                            raise TargetStitchException(
+                                'Message {} is missing key property {}'.format(
+                                    i, k))
         LOGGER.info('Batch is valid')
 
 


### PR DESCRIPTION
encountered this error in dry-run mode when piping in records without keys:

```
CRITICAL 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/target-stitch/bin/target-stitch", line 11, in <module>
    load_entry_point('target-stitch', 'console_scripts', 'target-stitch')()
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 439, in main
    raise exc
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 426, in main
    main_impl()
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 420, in main_impl
    args.batch_delay_seconds).consume(queue)
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 339, in consume
    self.flush()
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 285, in flush
    handler.handle_batch(self.messages, stream_meta.schema, stream_meta.key_properties)
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 167, in handle_batch
    for k in key_names:
TypeError: 'NoneType' object is not iterable
```

this change makes it so that we only validate the presence of keys in data when there are keys to look for