### PR TITLE
Report memory usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='target-stitch',
           'mock==2.0.0',
           'requests==2.18.4',
           'singer-python==3.1.0',
+          'psutil==5.3.1'
       ],
       entry_points='''
           [console_scripts]

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -43,6 +43,7 @@ class TargetStitchException(Exception):
     pass
 
 class MemoryReporter(Thread):
+    '''Logs memory usage every 30 seconds'''
 
     def __init__(self):
         self.process = psutil.Process()
@@ -50,7 +51,7 @@ class MemoryReporter(Thread):
 
     def run(self):
         while True:
-            LOGGER.debug('Virtual memory usage: %.2f%% of total: %s',
+            LOGGER.info('Virtual memory usage: %.2f%% of total: %s',
                         self.process.memory_percent(),
                         self.process.memory_info())
             time.sleep(30.0)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -51,9 +51,9 @@ class MemoryReporter(Thread):
 
     def run(self):
         while True:
-            LOGGER.info('Virtual memory usage: %.2f%% of total: %s',
-                        self.process.memory_percent(),
-                        self.process.memory_info())
+            LOGGER.debug('Virtual memory usage: %.2f%% of total: %s',
+                         self.process.memory_percent(),
+                         self.process.memory_info())
             time.sleep(30.0)
 
 


### PR DESCRIPTION
We're seeing cases where target-stitch is using way too much memory. Adding a thread that periodically reports memory at the debug level. Here's an example of the output:

```
INFO Virtual memory usage: 21.68% of total: pmem(rss=898813952, vms=1094270976, shared=4399104, text=3121152, lib=0, data=1029922816, dirty=0)
```