### PR TITLE
Use less memory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='target-stitch',
           'mock==2.0.0',
           'requests==2.18.4',
           'singer-python==3.1.0',
+          'psutil==5.3.1'
       ],
       entry_points='''
           [console_scripts]

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -43,6 +43,7 @@ class TargetStitchException(Exception):
     pass
 
 class MemoryReporter(Thread):
+    '''Logs memory usage every 30 seconds'''
 
     def __init__(self):
         self.process = psutil.Process()
@@ -50,7 +51,7 @@ class MemoryReporter(Thread):
 
     def run(self):
         while True:
-            LOGGER.debug('Virtual memory usage: %.2f%% of total: %s',
+            LOGGER.info('Virtual memory usage: %.2f%% of total: %s',
                         self.process.memory_percent(),
                         self.process.memory_info())
             time.sleep(30.0)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -51,9 +51,9 @@ class MemoryReporter(Thread):
 
     def run(self):
         while True:
-            LOGGER.info('Virtual memory usage: %.2f%% of total: %s',
-                        self.process.memory_percent(),
-                        self.process.memory_info())
+            LOGGER.debug('Virtual memory usage: %.2f%% of total: %s',
+                         self.process.memory_percent(),
+                         self.process.memory_info())
             time.sleep(30.0)
 
 

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -241,7 +241,12 @@ class TargetStitch(object):
     '''
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, handlers, state_writer, max_batch_bytes, max_batch_records, batch_delay_seconds):
+    def __init__(self, # pylint: disable=too-many-arguments
+                 handlers,
+                 state_writer,
+                 max_batch_bytes,
+                 max_batch_records,
+                 batch_delay_seconds):
         self.messages = []
         self.buffer_size_bytes = 0
         self.state = None
@@ -408,7 +413,6 @@ def main_impl():
             Thread(target=collect).start()
         handlers.append(StitchHandler(token, stitch_url, args.max_batch_bytes))
 
-    # TODO: Figure out a better queue limit
     # queue = Queue(args.max_batch_records)
     reader = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     TargetStitch(handlers,

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -50,9 +50,9 @@ class MemoryReporter(Thread):
 
     def run(self):
         while True:
-            LOGGER.debug('Virtual memory usage: %.2f%% of total: %s',
-                         self.process.memory_percent(),
-                         self.process.memory_info())
+            LOGGER.info('Virtual memory usage: %.2f%% of total: %s',
+                        self.process.memory_percent(),
+                        self.process.memory_info())
             time.sleep(30.0)
 
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -63,7 +63,7 @@ class TestTargetStitch(unittest.TestCase):
         self.client = DummyClient()
         self.out = io.StringIO()
         self.target_stitch = target_stitch.TargetStitch(
-            [self.client], self.out, 20000, 100000)
+            [self.client], self.out, 4000000, 20000, 100000)
 
     def test_persist_lines_fails_without_key_properties(self):
         recs = [

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -7,7 +7,7 @@ import sys
 import datetime
 import jsonschema
 import decimal
-from queue import Queue
+
 from decimal import Decimal
 from jsonschema import ValidationError, Draft4Validator, validators, FormatChecker
 from singer import ActivateVersionMessage, RecordMessage
@@ -25,11 +25,7 @@ class DummyClient(object):
              'key_names': key_names})
 
 def message_queue(messages):
-    queue = Queue(-1)
-    for m in messages:
-        queue.put(json.dumps(m))
-    queue.put(None)
-    return queue
+    return [json.dumps(m) for m in messages]
 
 def persist_all(recs):
     with DummyClient() as client:
@@ -50,11 +46,7 @@ schema = {"type": "SCHEMA",
 
 def load_sample_lines(filename):
     with open('tests/' + filename) as fp:
-        queue = Queue(-1)
-        for line in fp:
-            queue.put(line)
-        queue.put(None)
-        return queue
+        return [line for line in fp]
 
 
 class TestTargetStitch(unittest.TestCase):


### PR DESCRIPTION
Two changes to make us use less memory:

1. Get rid of the queue and use a single thread to read from stdin and make requests for the Gate.
2. Cut a batch when we hit 4 Mb of lines read.

Tests pass. tap-tester for hubspot succeeds.