### PR TITLE
Retry and better errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='target-stitch',
           'jsonschema==2.6.0',
           'mock==2.0.0',
           'requests==2.18.4',
-          'singer-python==3.1.0',
+          'singer-python==3.5.1',
           'psutil==5.3.1'
       ],
       entry_points='''

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -107,6 +107,15 @@ class BatchTooLargeException(TargetStitchException):
     create a batch with even one record.'''
     pass
 
+
+def stitch_error_message(response):
+
+    try:
+        return json.loads(response.json())['message']
+    except:
+        return '{}: {}'.format(response, response.content)
+    
+
 class StitchHandler(object): # pylint: disable=too-few-public-methods
     '''Sends messages to Stitch.'''
 
@@ -141,9 +150,10 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
                 LOGGER.info('Request %d of %d, %d bytes: %s: %s',
                             i + 1, len(bodies), len(body), resp, resp.content)
             else:
+                LOGGER.info('Bad response from Stitch: {}: {}'.format(resp, resp.content))
                 raise TargetStitchException(
-                    'Error posting data to Stitch: {}: {}'.format(
-                        resp, resp.content))
+                    'Error posting data to Stitch: ' +
+                    stitch_error_message(resp))
 
 
 class LoggingHandler(object):  # pylint: disable=too-few-public-methods

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -116,6 +116,9 @@ def stitch_error_message(response):
         return '{}: {}'.format(response, response.content)
     
 
+def _log_backoff(details):
+    LOGGER.info('Backing off: %s', details['value'])
+
 class StitchHandler(object): # pylint: disable=too-few-public-methods
     '''Sends messages to Stitch.'''
 
@@ -133,7 +136,7 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
 
     @backoff.on_predicate(backoff.expo,
                           lambda r: r.status_code // 100 == 5,
-                          on_backoff=lambda x: LOGGER.info('backing off: %s', str(x['value'])))
+                          on_backoff=_log_backoff)
     def send(self, data):
         url = self.stitch_url
         headers = self.headers()

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -135,7 +135,7 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
     @backoff.on_exception(backoff.expo,
                           RequestException,
                           giveup=singer.utils.exception_is_4xx,
-                          max_tries=3,
+                          max_tries=8,
                           on_backoff=_log_backoff)
     def send(self, data):
         '''Send the given data to Stitch, retrying on exceptions'''

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -125,6 +125,12 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
         self.session = requests.Session()
         self.max_batch_bytes = max_batch_bytes
 
+    def headers(self):
+        return {
+            'Authorization': 'Bearer {}'.format(self.token),
+            'Content-Type': 'application/json'
+        }
+        
     def handle_batch(self, messages, schema, key_names):
         '''Handle messages by sending them to Stitch.
 
@@ -133,9 +139,6 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
         requests.
 
         '''
-        headers = {
-            'Authorization': 'Bearer {}'.format(self.token),
-            'Content-Type': 'application/json'}
 
         LOGGER.info("Sending batch with %d messages for table %s to %s",
                     len(messages), messages[0].stream, self.stitch_url)
@@ -145,7 +148,7 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
         LOGGER.info('Split batch into %d requests', len(bodies))
         for i, body in enumerate(bodies):
             with TIMINGS.mode('posting'):
-                resp = self.session.post(self.stitch_url, headers=headers, data=body)
+                resp = self.session.post(self.stitch_url, headers=self.headers(), data=body)
             if resp.status_code // 100 == 2:
                 LOGGER.info('Request %d of %d, %d bytes: %s: %s',
                             i + 1, len(bodies), len(body), resp, resp.content)


### PR DESCRIPTION
Two changes:

1. Retry on 5xx responses, up to about five minutes.
2. If we get an error response that has a "message" field, pull it out and use that as the critical message.

Testing:

* [x] Succeed on 2xx response
* [x] Fail on single 4xx response
* [x] Fail on persistent 5xx response
* [x] Succeed on transient 5xx response
* [x] Fail on persistent connection error
* [x] Succeed on transient connection error