### PR TITLE
Fix bad error message

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -268,7 +268,9 @@ def serialize(messages, schema, key_names, max_bytes):
         return [serialized]
 
     if len(messages) <= 1:
-        raise BatchTooLargeException("A single record is larger than batch size limit of %d")
+        raise BatchTooLargeException(
+            "A single record is larger than batch size limit of {} Mb".format(
+                max_bytes // 1000000))
 
     pivot = len(messages) // 2
     l_half = serialize(messages[:pivot], schema, key_names, max_bytes)

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -7,6 +7,7 @@ import sys
 import datetime
 import jsonschema
 import decimal
+import re
 
 from decimal import Decimal
 from jsonschema import ValidationError, Draft4Validator, validators, FormatChecker
@@ -265,8 +266,10 @@ class TestSerialize(unittest.TestCase):
         self.assertEqual(8, len(self.serialize_with_limit(300)))
 
     def test_raises_if_cant_stay_in_limit(self):
-        with self.assertRaises(target_stitch.BatchTooLargeException):
-            self.serialize_with_limit(100)
+        data = 'a' * 4000000
+        message = RecordMessage(stream='colors', record=data)
+        with self.assertRaisesRegex(target_stitch.BatchTooLargeException, re.compile('batch size limit of 4 Mb')):
+            target_stitch.serialize([message], self.schema, self.key_names, 4000000)
 
     def test_does_not_drop_records(self):
         expected = [


### PR DESCRIPTION
When we hit the 4 Mb limit with a single message, we were giving an error message like

> A single record is larger than batch size limit of %d

We need to format the batch size limit into that string. This will now produce a message
like this:

> A single record is larger than batch size limit of 4 Mb