### PR TITLE
Improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 .ropeproject
 
 data-*.txt
+*~
+\#*
+.\#*

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,13 @@
 machine:
   python:
     version: 3.4.4
-    
+
 dependencies:
   pre:
     - pip install pylint
 
 test:
+  override:
+    - nosetests --ignore-files=integration_tests.py
   post:
     - pylint target_stitch

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -175,10 +175,12 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
                 except HTTPError as exc:
                     try:
                         response_body = exc.response.json()
-                        if 'message' in response_body:
+                        if isinstance(response_body, dict) and 'message' in response_body:
                             msg = response_body['message']
-                        elif 'error' in response_body:
+                        elif isinstance(response_body, dict) and 'error' in response_body:
                             msg = response_body['error']
+                        else:
+                            msg = '{}: {}'.format(exc.response, exc.response.content)
                     except: # pylint: disable=bare-except
                         LOGGER.exception('Exception while processing error response')
                         msg = '{}: {}'.format(exc.response, exc.response.content)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -180,7 +180,7 @@ class StitchHandler(object): # pylint: disable=too-few-public-methods
                         elif 'error' in response_body:
                             msg = response_body['error']
                     except: # pylint: disable=bare-except
-                        LOGGER.exception('bad')
+                        LOGGER.exception('Exception while processing error response')
                         msg = '{}: {}'.format(exc.response, exc.response.content)
                     raise TargetStitchException('Error persisting data for table ' +
                                                 '"' + messages[0].stream +'": ' +

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -500,7 +500,8 @@ def main():
     # can suppress the stack trace, otherwise we should include the stack
     # trace for debugging purposes, so re-raise the exception.
     except TargetStitchException as exc:
-        LOGGER.critical(exc)
+        for line in str(exc).splitlines():
+            LOGGER.critical(line)
         sys.exit(1)
     except Exception as exc:
         LOGGER.critical(exc)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -8,10 +8,15 @@ def load_sample_lines(filename):
     with open('tests/' + filename) as fp:
         return [line for line in fp]
 
+def token():
+    token = os.getenv('TARGET_STITCH_TEST_TOKEN')
+    if not token:
+        raise Exception('Integration tests require TARGET_STITCH_TEST_TOKEN environment variable to be set')
+    return token
+
 class IntegrationTest(unittest.TestCase):
     def setUp(self):
-        token = os.getenv('TARGET_STITCH_TEST_TOKEN')
-        handler = StitchHandler(token, DEFAULT_STITCH_URL, 4000000)
+        handler = StitchHandler(token(), DEFAULT_STITCH_URL, 4000000)
         out = io.StringIO()
         self.target_stitch = target_stitch.TargetStitch(
             [handler], out, 4000000, 20000, 100000)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,0 +1,27 @@
+import unittest
+import target_stitch
+from target_stitch import StitchHandler, TargetStitchException, DEFAULT_STITCH_URL
+import io
+import os
+
+def load_sample_lines(filename):
+    with open('tests/' + filename) as fp:
+        return [line for line in fp]
+
+class IntegrationTest(unittest.TestCase):
+    def setUp(self):
+        token = os.getenv('TARGET_STITCH_TEST_TOKEN')
+        handler = StitchHandler(token, DEFAULT_STITCH_URL, 4000000)
+        out = io.StringIO()
+        self.target_stitch = target_stitch.TargetStitch(
+            [handler], out, 4000000, 20000, 100000)
+
+class TestRecordWithNullKeyProperty(IntegrationTest):
+
+    def test(self):
+        queue = load_sample_lines('record_missing_key_property.json')
+        pattern = ('Error persisting data for table '
+                   '"test_record_missing_key_property": '
+                   'Record is missing key property id')
+        with self.assertRaisesRegex(TargetStitchException, pattern):
+            self.target_stitch.consume(queue)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -25,3 +25,18 @@ class TestRecordWithNullKeyProperty(IntegrationTest):
                    'Record is missing key property id')
         with self.assertRaisesRegex(TargetStitchException, pattern):
             self.target_stitch.consume(queue)
+
+class TestNoToken(unittest.TestCase):
+
+    def setUp(self):
+        token = None
+        handler = StitchHandler(token, DEFAULT_STITCH_URL, 4000000)
+        out = io.StringIO()
+        self.target_stitch = target_stitch.TargetStitch(
+            [handler], out, 4000000, 20000, 100000)
+
+    def test(self):
+        queue = load_sample_lines('record_missing_key_property.json')
+        pattern = 'Not Authorized'
+        with self.assertRaisesRegex(TargetStitchException, pattern):
+            self.target_stitch.consume(queue)

--- a/tests/record_missing_key_property.json
+++ b/tests/record_missing_key_property.json
@@ -1,0 +1,2 @@
+{"type": "SCHEMA", "stream": "test_record_missing_key_property", "key_properties": ["id"], "schema": {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}}}
+{"type": "RECORD", "stream": "test_record_missing_key_property", "record": {"name": "Mike"}}

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -105,7 +105,6 @@ class TestTargetStitch(unittest.TestCase):
 
         self.assertEqual(batch['key_names'], ['id'])
 
-
     def test_persist_last_state_when_stream_ends_with_record(self):
         self.target_stitch.max_batch_records = 3
         inputs = [


### PR DESCRIPTION
A few improvements for how we handle a 400 response from Stitch:

1. Include the name of the stream we were trying to persist in the TargetStitchException we raise, so it shows up in the CRITICAL error message.
2. Get the "message" or "error" field out of the response, rather than displaying the whole stringified response object.
3. Stitch may return a multi-line error message in the response, so split the message on newline and log each line separately.

Here are some examples of target-stitch before and after this change:

### Record missing key property

#### Before

```
CRITICAL Error sending data to Stitch: <Response [400]>: b'{"error":"Record is missing key property id"}'
```

#### After

```
CRITICAL Error persisting data for table "test_record_missing_key_property": Record is missing key property id
```

#### Before

```
CRITICAL Error sending data to Stitch: <Response [400]>: b'{"error":"Record 0 did not conform to schema:\\n#/name: expected type: String, found: Integer\\n"}'
```

#### After

```
CRITICAL Error persisting data for table "users": Record 0 did not conform to schema:
CRITICAL #/name: expected type: String, found: Integer
```