### PR TITLE
Update singer-python to newest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='target-stitch',
           'jsonschema==2.6.0',
           'mock==2.0.0',
           'requests==2.18.4',
-          'singer-python==5.0.0',
+          'singer-python>=5.0.12',
           'psutil==5.3.1'
       ],
       entry_points='''


### PR DESCRIPTION
There is a conflict with the tap-template and target-stitch. 

Target Stitch requires exactly 5.0.0, while tap-template requires 5.0.12