### PR TITLE
update error to clarify the max size of a record

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -289,7 +289,7 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes):
 
     if len(messages) <= 1:
         raise BatchTooLargeException(
-            "A single record is larger than batch size limit of {} Mb".format(
+            "A single record is larger than the Stitch API limit of {} Mb".format(
                 max_bytes // 1000000))
 
     pivot = len(messages) // 2


### PR DESCRIPTION
Removed the word "batch" for clarity of error message.