### PR TITLE
Fix/time extracted serialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='target-stitch',
           'jsonschema==2.6.0',
           'mock==2.0.0',
           'requests==2.18.4',
-          'singer-python==5.0.0',
+          'singer-python==5.0.14',
           'psutil==5.3.1'
       ],
       entry_points='''

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -293,8 +293,9 @@ class TestSerialize(unittest.TestCase):
     def test_serialize_time_extracted(self):
         """ Test that we're not corrupting timestamps with cross platform parsing. (Test case for OSX, specifically) """
         expected = "1970-01-01T03:45:23.000000Z"
+        test_time = datetime.datetime(1970, 1, 1, 3, 45, 23, tzinfo=pytz.utc)
 
-        record = [RecordMessage("greetings",'{greeting: "hi"}', time_extracted=datetime.datetime(1970, 1, 1, 3, 45, 23, tzinfo=pytz.utc))]
+        record = [RecordMessage("greetings",'{greeting: "hi"}', time_extracted=test_time)]
         schema = '{"type": "object", "properties": {"greeting": {"type": "string"}}}'
         batch = target_stitch.serialize(record, schema, [], [], 1000)[0]
         actual = json.loads(batch)["messages"][0]["time_extracted"]


### PR DESCRIPTION
Singer-python has been updated to use a cross-platform parsing method for `strftime` added a test case for the failure mode and upgraded singer-python to use this new version.