### PR TITLE
Fix/ensure unique sequence per message

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -36,6 +36,8 @@ LOGGER = singer.get_logger().getChild('target_stitch')
 StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_properties'])
 
 DEFAULT_STITCH_URL = 'https://api.stitchdata.com/v2/import/batch'
+DEFAULT_MAX_BATCH_BYTES = 4000000
+DEFAULT_MAX_BATCH_RECORDS = 20000
 
 class TargetStitchException(Exception):
     '''A known exception for which we don't need to print a stack trace'''
@@ -466,8 +468,8 @@ def main_impl():
         '-q', '--quiet',
         help='Suppress info-level logging',
         action='store_true')
-    parser.add_argument('--max-batch-records', type=int, default=20000)
-    parser.add_argument('--max-batch-bytes', type=int, default=4000000)
+    parser.add_argument('--max-batch-records', type=int, default=DEFAULT_MAX_BATCH_RECORDS)
+    parser.add_argument('--max-batch-bytes', type=int, default=DEFAULT_MAX_BATCH_BYTES)
     parser.add_argument('--batch-delay-seconds', type=float, default=300.0)
     args = parser.parse_args()
 


### PR DESCRIPTION
The `sequence` field should be unique across all messages. Currently, we use the current millis (`time.time() * 1000`). It is entirely possible for multiple messages to be processed within the same millisecond, however. This is especially bad records for the same table have the same `key_properties` value as they can not be deduplicated.

In order to fix this issue, we will still use the current millis but append a suffix which contains the record number which is zero-filled to ensure that there is no clashing in the future.