### PR TITLE
Feature/buffer all streams together

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -263,7 +263,7 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
                         'Record does not pass schema validation: {}'.format(e))
 
 
-        LOGGER.info('Batch is valid')
+        LOGGER.info('Batch of %d records is valid', len(messages))
 
 def generate_sequence(message_num, max_records):
     '''Generates a unique sequence number based on the current time millis

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -424,7 +424,6 @@ class TargetStitch:
 
         elif isinstance(message, (singer.RecordMessage, singer.ActivateVersionMessage)):
             if self.messages and (
-                    message.stream != self.messages[0].stream or
                     message.version != self.messages[0].version):
                 self.flush()
             self.messages.append(message)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -434,6 +434,19 @@ class TargetStitch:
 
             self.buffer_size_bytes += len(line)
 
+            # The relevant limits are as follows:
+            #
+            # 1. bytes matters in aggregate because we don't want to
+            #    increase the memory usage of the target.
+            #
+            # 2. messages matters per stream because so long as we haven't
+            #    reached the memory ceiling we only care about the stream
+            #    batches down to the request size and each stream batch
+            #    will be sent as a separate request.
+            #
+            # 3. seconds matters in aggregate because we don't want to
+            #    send requests for each stream type separately because
+            #    that would make state tracking much more complicated.
             num_bytes = self.buffer_size_bytes
             num_messages = len(self.messages.get(message.stream))
             num_seconds = time.time() - self.time_last_batch_sent


### PR DESCRIPTION
target-stitch flushes its messages when it receives records for a different stream then those currently buffered.  

This PR removes that check so that records for multiple streams are buffered together.  This prevents interleaved streams from continuously producing batches of 1 record.  