### PR TITLE
Flush buffer if enough time has passed when state message is received

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -445,6 +445,15 @@ class TargetStitch:
         elif isinstance(message, singer.StateMessage):
             self.state = message.value
 
+            # only check time since state message does not increase num_messages or
+            # num_bytes for the batch
+            num_seconds = time.time() - self.time_last_batch_sent
+            if num_seconds >= self.batch_delay_seconds:
+                LOGGER.debug('Flushing %d bytes, %d messages, after %.2f seconds',
+                             self.buffer_size_bytes, len(self.messages), num_seconds)
+                self.flush()
+
+
 
     def consume(self, reader):
         '''Consume all the lines from the queue, flushing when done.'''


### PR DESCRIPTION
This PR modifies target-stitch so that, when a state message is received, it checks how much time has passed since the last flush, and if it is greater than the limit, it flushes the buffer.  

This addresses a bug where a tap was writing state updates that reduced the size of a query window, but never writing records, so the state was never being written by the target since the target only attempted to flush when it received record messages.

The only time this change should have an effect is when a tap is writing records infrequently, but writing state somewhat frequently.  

I tested this by cloning the connection with the bug mentioned above, and verifying that it fixed the issue and did not affect any other functionality.  I also tested a few other connections with this change and verified that they also did not see a change in functionality.  