### PR TITLE
parsing-improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='target-stitch',
           'jsonschema==2.6.0',
           'mock==2.0.0',
           'requests==2.20.0',
-          'singer-python==5.7.0',
+          'singer-python==5.8.0',
           'psutil==5.3.1',
           'simplejson==3.11.1'
       ],

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ setup(name='target-stitch',
           'jsonschema==2.6.0',
           'mock==2.0.0',
           'requests==2.20.0',
-          'singer-python==5.0.15',
+          'singer-python==5.7.0',
           'psutil==5.3.1',
+          'simplejson==3.11.1'
       ],
       extras_require={
           'dev': [

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -27,6 +27,7 @@ import psutil
 import requests
 from requests.exceptions import RequestException, HTTPError
 from jsonschema import ValidationError, Draft4Validator, FormatChecker
+import simplejson
 import pkg_resources
 import singer
 import backoff
@@ -329,7 +330,7 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_record
     # This will affect very few data points and we have chosen to leave
     # conversion as is for now.
 
-    serialized = json.dumps(body)
+    serialized = simplejson.dumps(body)
     LOGGER.debug('Serialized %d messages into %d bytes', len(messages), len(serialized))
 
     if len(serialized) < max_bytes:

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -94,17 +94,6 @@ class Timings:
 TIMINGS = Timings()
 
 
-def float_to_decimal(value):
-    '''Walk the given data structure and turn all instances of float into
-    double.'''
-    if isinstance(value, float):
-        return Decimal(str(value))
-    if isinstance(value, list):
-        return [float_to_decimal(child) for child in value]
-    if isinstance(value, dict):
-        return {k: float_to_decimal(v) for k, v in value.items()}
-    return value
-
 class BatchTooLargeException(TargetStitchException):
     '''Exception for when the records and schema are so large that we can't
     create a batch with even one record.'''
@@ -245,20 +234,18 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
     '''Validates input messages against their schema.'''
 
     def __init__(self):
-        getcontext().prec = 10000
+        getcontext().prec = 76
 
     def handle_batch(self, messages, schema, key_names, bookmark_names=None): # pylint: disable=no-self-use,unused-argument
         '''Handles messages by validating them against schema.'''
-        schema = float_to_decimal(schema)
         validator = Draft4Validator(schema, format_checker=FormatChecker())
         for i, message in enumerate(messages):
             if isinstance(message, singer.RecordMessage):
-                data = float_to_decimal(message.record)
                 try:
-                    validator.validate(data)
+                    validator.validate(message.record)
                     if key_names:
                         for k in key_names:
-                            if k not in data:
+                            if k not in message.record:
                                 raise TargetStitchException(
                                     'Message {} is missing key property {}'.format(
                                         i, k))

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -7,6 +7,7 @@ import sys
 import datetime
 import pytz
 import jsonschema
+import simplejson
 import decimal
 import re
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -12,7 +12,7 @@ import re
 
 from decimal import Decimal
 from jsonschema import ValidationError, Draft4Validator, validators, FormatChecker
-from singer import ActivateVersionMessage, RecordMessage, utils
+from singer import ActivateVersionMessage, RecordMessage, utils, parse_message
 
 
 class DummyClient(object):
@@ -311,7 +311,7 @@ class TestSerialize(unittest.TestCase):
         for decimal_str in decimal_strs:
             record_str = self.create_raw_record(decimal_str)
             record_message_str = self.create_raw_record_message(record_str)
-            deserialized_record = singer.parse_message(record_message_str).record
+            deserialized_record = parse_message(record_message_str).record
             serialized_record_str = simplejson.dumps(deserialized_record)
             self.assertEqual(record_str, serialized_record_str)
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -209,24 +209,6 @@ class TestTargetStitch(unittest.TestCase):
         self.assertEqual(1, batches[0]['messages'][0].version)
         self.assertEqual(2, batches[1]['messages'][0].version)
 
-class TestFloatToDecimal(unittest.TestCase):
-
-    def test_scalar_float(self):
-        self.assertTrue(isinstance(target_stitch.float_to_decimal(1.2), Decimal))
-
-    def test_scalar_non_float(self):
-        self.assertTrue(isinstance(target_stitch.float_to_decimal('hi'), str))
-
-    def test_array(self):
-        result = target_stitch.float_to_decimal([1.2, 'hi'])
-        self.assertTrue(isinstance(result[0], Decimal))
-        self.assertTrue(isinstance(result[1], str))
-
-    def test_dict(self):
-        result = target_stitch.float_to_decimal({'float': 1.2, 'str': 'hi'})
-        self.assertTrue(isinstance(result['float'], Decimal))
-        self.assertTrue(isinstance(result['str'], str))
-
 class TestSerialize(unittest.TestCase):
 
     def setUp(self):
@@ -301,6 +283,38 @@ class TestSerialize(unittest.TestCase):
         actual = json.loads(batch)["messages"][0]["time_extracted"]
 
         self.assertEqual(expected, actual)
+
+
+    def create_raw_record(self, value):
+        return '{"value": ' + value + '}'
+
+    def create_raw_record_message(self,raw_record):
+        return '{"type": "RECORD", "stream": "test", "record": ' + raw_record + '}'
+
+
+    def test_deserialize_and_serialize_decimals(self):
+        decimal_strs = [
+            '-9999999999999999.9999999999999999999999',
+            '0',
+            '9999999999999999.9999999999999999999999',
+            '-7187498962233394.3739812942138415666763',
+            '9273972760690975.2044306442955715221042',
+            '29515565286974.1188802122612813004366',
+            '9176089101347578.2596296292040288441238',
+            '-8416853039392703.306423225471199148379',
+            '1285266411314091.3002668125515694162268',
+            '6051872750342125.3812886238958681227336',
+            '-1132031605459408.5571559429308939781468',
+            '-6387836755056303.0038029604189860431045',
+            '4526059300505414'
+        ]
+        for decimal_str in decimal_strs:
+            record_str = self.create_raw_record(decimal_str)
+            record_message_str = self.create_raw_record_message(record_str)
+            deserialized_record = singer.parse_message(record_message_str).record
+            serialized_record_str = simplejson.dumps(deserialized_record)
+            self.assertEqual(record_str, serialized_record_str)
+
 
 class test_use_batch_url(unittest.TestCase):
 


### PR DESCRIPTION
1, dump numbers as decimals(avoid float rounding)
2. use new singer python to load json input number as decimals(avoid float rounding)
3. parse time_extracted more efficiently.