### PR TITLE
terminate target on exception  within the flush_states callback

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from decimal import Decimal, getcontext
 import asyncio
 import concurrent
+from pprint import pformat
 import simplejson
 import psutil
 
@@ -37,7 +38,7 @@ import backoff
 
 import singer
 import ciso8601
-from pprint import pformat
+
 
 LOGGER = singer.get_logger().getChild('target_stitch')
 

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -37,6 +37,7 @@ import backoff
 
 import singer
 import ciso8601
+from pprint import pformat
 
 LOGGER = singer.get_logger().getChild('target_stitch')
 
@@ -164,7 +165,7 @@ class StitchHandler: # pylint: disable=too-few-public-methods
         global SEND_EXCEPTION
 
         completed_count = 0
-        from pprint import pformat
+
 
         #NB> if/when the first coroutine errors out, we will record it for examination by the main threa.
         #if/when this happens, no further flushing of state should ever occur.  the main thread, in fact,

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -185,13 +185,12 @@ class StitchHandler: # pylint: disable=too-few-public-methods
                     #if this were None, we would have just nuked the client's state
                     if s:
                         line = simplejson.dumps(s)
-                        #NB> possible state_writer.close() but probably did not happen
-                        # because we are missing exception calling callback for <Future at 0x7f98df4ffdd8 state=finished returned dict>
                         state_writer.write("{}\n".format(line))
                         state_writer.flush()
-                    else:
-                        break
-                    PENDING_REQUESTS = PENDING_REQUESTS[completed_count:]
+                else:
+                    break
+
+            PENDING_REQUESTS = PENDING_REQUESTS[completed_count:]
 
         except BaseException as err:
             SEND_EXCEPTION = err

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -546,4 +546,4 @@ class StateEdgeCases(unittest.TestCase):
 if __name__== "__main__":
     test1 = StateEdgeCases()
     test1.setUp()
-    test1.test_will_not_output_empty_state()
+    test1.test_trailing_state_after_final_message()


### PR DESCRIPTION
# Description of change
     If an Exception occurs within the flush_states callback, it is imperative that the global variable SEND_EXCEPTION is to set.  This will result in the main thread terminating instead of allowing the process to live with a shattered event loop.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
     Verified that that target dies properly when an exception is encountered with flush_states.

# Risks
     None

# Rollback steps
 - revert this branch
