### PR TITLE
Feature/activate version drains pending requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,7 @@ jobs:
           command: |
             # Need to re-activate the virtualenv
             source ~/.virtualenvs/target-stitch/bin/activate
-            nosetests
+            nosetests tests/activate_version_tests.py 
+            nosetests --ignore-files=activate_version_tests.py
+            #nosetests
             pylint target_stitch "--extension-pkg-whitelist=ciso8601"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: |
             # Need to re-activate the virtualenv
             source ~/.virtualenvs/target-stitch/bin/activate
-            nosetests tests/activate_version_tests.py 
-            nosetests --ignore-files=activate_version_tests.py
+            nosetests -v tests/activate_version_tests.py
+            nosetests -v --ignore-files=activate_version_tests.py
             #nosetests
             pylint target_stitch "--extension-pkg-whitelist=ciso8601"

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -750,7 +750,7 @@ async def post_coroutine(url, headers, data, verify_ssl):
         result_body = None
         try:
             result_body = await response.json()
-        except BaseException as ex: #pylint: disable=bare-except
+        except BaseException as ex: #pylint: disable=unused-variable
             raise StitchClientResponseError(response.status, "unable to parse response body as json")
 
         if response.status // 100 != 2:

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -744,7 +744,7 @@ def exception_is_4xx(ex):
                       giveup=exception_is_4xx,
                       on_backoff=_log_backoff)
 async def post_coroutine(url, headers, data, verify_ssl):
-    LOGGER.info("POST starting: %s ssl(%s)", url, verify_ssl)
+    # LOGGER.info("POST starting: %s ssl(%s)", url, verify_ssl)
     global OUR_SESSION
     async with OUR_SESSION.post(url, headers=headers, data=data, raise_for_status=False, verify_ssl=verify_ssl) as response:
         result_body = None

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -221,9 +221,11 @@ class StitchHandler: # pylint: disable=too-few-public-methods
         #this is to ensure ordering in the case of Full Table replication where the Activate Version,
         #must arrive AFTER all of the relevant data.
         if len(PENDING_REQUESTS) > 0 and contains_activate_version:
+            LOGGER.info('Sending batch with ActivateVersion. Flushing PENDING_REQUESTS first')
             finish_requests()
 
         if len(PENDING_REQUESTS) >= self.turbo_boost_factor:
+
             #wait for to finish the first future before resuming the main thread
             finish_requests(self.turbo_boost_factor - 1)
 

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -167,7 +167,6 @@ class StitchHandler: # pylint: disable=too-few-public-methods
 
         completed_count = 0
 
-
         #NB> if/when the first coroutine errors out, we will record it for examination by the main threa.
         #if/when this happens, no further flushing of state should ever occur.  the main thread, in fact,
         #should shutdown quickly after it spots the exception
@@ -205,7 +204,7 @@ class StitchHandler: # pylint: disable=too-few-public-methods
             'Content-Type': 'application/json'
         }
 
-    def send(self, data, state_writer, state):
+    def send(self, data, contains_activate_version, state_writer, state):
         '''Send the given data to Stitch, retrying on exceptions'''
         global PENDING_REQUESTS
         global SEND_EXCEPTION
@@ -218,10 +217,13 @@ class StitchHandler: # pylint: disable=too-few-public-methods
         if os.environ.get("TARGET_STITCH_SSL_VERIFY") == 'false':
             verify_ssl = False
 
+        #NB> before we send any activate_versions we must ensure that all PENDING_REQUETS complete.
+        #this is to ensure ordering in the case of Full Table replication where the Activate Version,
+        #must arrive AFTER all of the relevant data.
+        if len(PENDING_REQUESTS) > 0 and contains_activate_version:
+            finish_requests()
 
         if len(PENDING_REQUESTS) >= self.turbo_boost_factor:
-            #LOGGER.info("pendingRequest(%s) >= turbo_boost_factor(%s) waiting...", len(PENDING_REQUESTS), self.turbo_boost_factor)
-
             #wait for to finish the first future before resuming the main thread
             finish_requests(self.turbo_boost_factor - 1)
 
@@ -249,7 +251,7 @@ class StitchHandler: # pylint: disable=too-few-public-methods
         future.add_done_callback(functools.partial(self.flush_states, state_writer))
 
 
-    def handle_batch(self, messages, schema, key_names, bookmark_names=None, state_writer=None, state=None):
+    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names=None, state_writer=None, state=None, ):
         '''Handle messages by sending them to Stitch.
 
         If the serialized form of the messages is too large to fit into a
@@ -276,7 +278,7 @@ class StitchHandler: # pylint: disable=too-few-public-methods
                 if i + 1 == len(bodies):
                     flushable_state = state
 
-                self.send(body, state_writer, flushable_state)
+                self.send(body, contains_activate_version, state_writer, flushable_state)
 
 class LoggingHandler:  # pylint: disable=too-few-public-methods
     '''Logs records to a local output file.'''
@@ -294,7 +296,7 @@ class LoggingHandler:  # pylint: disable=too-few-public-methods
             state_writer.flush()
 
 
-    def handle_batch(self, messages, schema, key_names, bookmark_names=None, state_writer=None, state=None): #pylint: disable=unused-argument
+    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names=None, state_writer=None, state=None): #pylint: disable=unused-argument
         '''Handles a batch of messages by saving them to a local output file.
 
         Serializes records in the same way StitchHandler does, so the
@@ -336,7 +338,7 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
             state_writer.write("{}\n".format(line))
             state_writer.flush()
 
-    def handle_batch(self, messages, schema, key_names, bookmark_names=None, state_writer=None, state=None): # pylint: disable=no-self-use,unused-argument
+    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names=None, state_writer=None, state=None): # pylint: disable=no-self-use,unused-argument
         '''Handles messages by validating them against schema.'''
         LOGGER.info("ValidatingHandler handle_batch")
         validator = Draft4Validator(schema, format_checker=FormatChecker())
@@ -455,6 +457,7 @@ class TargetStitch:
                  max_batch_records,
                  batch_delay_seconds):
         self.messages = []
+        self.contains_activate_version = False
         self.buffer_size_bytes = 0
         self.state = None
 
@@ -487,13 +490,16 @@ class TargetStitch:
             stream_meta = self.stream_meta[self.messages[0].stream]
             for handler in self.handlers:
                 handler.handle_batch(self.messages,
+                                     self.contains_activate_version,
                                      stream_meta.schema,
                                      stream_meta.key_properties,
                                      stream_meta.bookmark_properties,
                                      self.state_writer,
                                      self.state)
+
             self.time_last_batch_sent = time.time()
             self.messages = []
+            self.contains_activate_version = False
             self.state = None
             self.buffer_size_bytes = 0
 
@@ -535,6 +541,8 @@ class TargetStitch:
 
             self.messages.append(message)
             self.buffer_size_bytes += len(line)
+            if isinstance(message, singer.ActivateVersionMessage):
+                self.contains_activate_version = True
 
             num_bytes = self.buffer_size_bytes
             num_messages = len(self.messages)
@@ -736,15 +744,15 @@ def exception_is_4xx(ex):
                       giveup=exception_is_4xx,
                       on_backoff=_log_backoff)
 async def post_coroutine(url, headers, data, verify_ssl):
-    # LOGGER.info("POST starting: %s ssl(%s)", url, verify_ssl)
+    LOGGER.info("POST starting: %s ssl(%s)", url, verify_ssl)
     global OUR_SESSION
     async with OUR_SESSION.post(url, headers=headers, data=data, raise_for_status=False, verify_ssl=verify_ssl) as response:
         result_body = None
         try:
             result_body = await response.json()
-        except: #pylint: disable=bare-except
-            pass
-        # LOGGER.info("POST response: %s %s", response.status, result_body)
+        except BaseException as ex: #pylint: disable=bare-except
+            raise StitchClientResponseError(response.status, "unable to parse response body as json")
+
         if response.status // 100 != 2:
             raise StitchClientResponseError(response.status, result_body)
 

--- a/tests/activate_version_tests.py
+++ b/tests/activate_version_tests.py
@@ -1,0 +1,97 @@
+import unittest
+import target_stitch
+from target_stitch import StitchHandler, TargetStitchException, DEFAULT_STITCH_URL, finish_requests
+import io
+import json
+import simplejson
+import asyncio
+
+try:
+    from tests.gate_mocks import mock_out_of_order_all_200
+except ImportError:
+    from gate_mocks  import mock_out_of_order_all_200
+
+
+class FakePost:
+    def __init__(self, requests_sent, makeFakeResponse):
+        self.requests_sent = requests_sent
+        self.makeFakeResponse = makeFakeResponse
+
+    async def __aenter__(self):
+        return self.makeFakeResponse(self.requests_sent)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await asyncio.sleep(1)
+
+class FakeSession:
+    def __init__(self, makeFakeResponse):
+        self.requests_sent = 0
+        self.bodies_sent = []
+        self.makeFakeResponse = makeFakeResponse
+
+    def post(self, url, *, data, **kwargs):
+        self.requests_sent = self.requests_sent + 1
+        self.bodies_sent.append(data)
+        return FakePost(self.requests_sent, self.makeFakeResponse)
+
+class ActivateVersion(unittest.TestCase):
+    def fake_flush_states(self, state_writer, future):
+        self.flushed_state_count = self.flushed_state_count + 1
+        if self.flushed_state_count == 1:
+            #2nd request has not begun because it contains an ActivateVersion and must wait for 1 to complete
+            self.assertEqual(1, len(target_stitch.PENDING_REQUESTS), "ActivateVersion request should not have been issues until 1st request completed")
+            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
+            self.assertEqual({'bookmarks': {'chicken_stream': {'id': 1}}}, target_stitch.PENDING_REQUESTS[0][1])
+        elif self.flushed_state_count == 2:
+            self.assertEqual(100, len(target_stitch.PENDING_REQUESTS))
+            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
+            self.assertEqual(None, target_stitch.PENDING_REQUESTS[0][1])
+        else:
+            raise Exception('flushed state should only have been called twice')
+
+        self.og_flush_states(state_writer, future)
+
+    def setUp(self):
+        token = None
+
+        handler = StitchHandler(token,
+                                DEFAULT_STITCH_URL,
+                                target_stitch.DEFAULT_MAX_BATCH_BYTES,
+                                2,
+                                10)
+        self.out = io.StringIO()
+        self.target_stitch = target_stitch.TargetStitch(
+            [handler], self.out, 4000000, 2, 100000)
+        self.queue = [simplejson.dumps({"type": "SCHEMA", "stream": "chicken_stream",
+                                  "key_properties": ["my_float"],
+                                  "schema": {"type": "object",
+                                             "properties": {"my_float": {"type": "number"}}}})]
+        target_stitch.SEND_EXCEPTION = None
+        target_stitch.PENDING_REQUESTS = []
+        self.og_flush_states = StitchHandler.flush_states
+        self.flushed_state_count = 0
+        StitchHandler.flush_states = self.fake_flush_states
+
+
+    def test_activate_version_finishes_pending_requests(self):
+        target_stitch.OUR_SESSION = FakeSession(mock_out_of_order_all_200)
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "version":1, "record": {"id": 1, "name": "Mike"}}))
+        self.queue.append(json.dumps({"type":"STATE", "value":{"bookmarks":{"chicken_stream":{"id": 1 }}}}))
+        #will flush here after 2 records
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", 'version':1, "record": {"id": 2, "name": "Paul"}}))
+        self.queue.append(json.dumps({"type":"ACTIVATE_VERSION", 'stream': 'chicken_stream', 'version': 1 }))
+        #will flush here after 2 records
+
+
+        self.target_stitch.consume(self.queue)
+        finish_requests()
+
+        #request 2 would ordinarily complete first because the mock_out_of_order_all_200, but because
+        #request 2 contains an ACTIVATE_VERSION, it will not even be sent until request 1 completes
+
+
+if __name__== "__main__":
+    test1 = ActivateVersion()
+    test1.setUp()
+    test1.test_activate_version_finishes_pending_requests()
+    #test1.test_unparseable_json_response()

--- a/tests/activate_version_tests.py
+++ b/tests/activate_version_tests.py
@@ -37,22 +37,38 @@ class FakeSession:
 class ActivateVersion(unittest.TestCase):
     def fake_flush_states(self, state_writer, future):
         self.flushed_state_count = self.flushed_state_count + 1
+
         if self.flushed_state_count == 1:
             #2nd request has not begun because it contains an ActivateVersion and must wait for 1 to complete
-            self.assertEqual(1, len(target_stitch.PENDING_REQUESTS), "ActivateVersion request should not have been issues until 1st request completed")
-            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
-            self.assertEqual({'bookmarks': {'chicken_stream': {'id': 1}}}, target_stitch.PENDING_REQUESTS[0][1])
+            if len(target_stitch.PENDING_REQUESTS) != 1:
+                self.first_flush_error = "ActivateVersion request should not have been issues until 1st request completed: wrong pending request count for first flush"
+
+            if future != target_stitch.PENDING_REQUESTS[0][0]:
+                self.first_flush_error = "ActivateVersion request should not have been issues until 1st request completed: received wrong future for first flush"
+
+            if  target_stitch.PENDING_REQUESTS[0][1] != {'bookmarks': {'chicken_stream': {'id': 1}}}:
+                self.first_flush_error = "ActivateVersion request should not have been issues until 1st request completed: wrong state for first flush"
+
         elif self.flushed_state_count == 2:
-            self.assertEqual(100, len(target_stitch.PENDING_REQUESTS))
-            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
-            self.assertEqual(None, target_stitch.PENDING_REQUESTS[0][1])
+            if len(target_stitch.PENDING_REQUESTS) != 1:
+                self.second_flush_error = "ActivateVersion request should not have been issues until 1st request completed: wrong pending request count for second flush"
+
+            if future != target_stitch.PENDING_REQUESTS[0][0]:
+                self.second_flush_error = "ActivateVersion request should not have been issues until 1st request completed: wrong future for second flush"
+
+            if target_stitch.PENDING_REQUESTS[0][1] is not None:
+                self.second_flush_error = "ActivateVersion request should not have been issues until 1st request completed: wrong state for second flush"
+
         else:
             raise Exception('flushed state should only have been called twice')
 
         self.og_flush_states(state_writer, future)
 
+
     def setUp(self):
         token = None
+        self.first_flush_error = None
+        self.second_flush_error = None
 
         handler = StitchHandler(token,
                                 DEFAULT_STITCH_URL,
@@ -75,6 +91,9 @@ class ActivateVersion(unittest.TestCase):
 
     def test_activate_version_finishes_pending_requests(self):
         target_stitch.OUR_SESSION = FakeSession(mock_out_of_order_all_200)
+        #request 2 would ordinarily complete first because the mock_out_of_order_all_200, but because
+        #request 2 contains an ACTIVATE_VERSION, it will not even be sent until request 1 completes
+
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "version":1, "record": {"id": 1, "name": "Mike"}}))
         self.queue.append(json.dumps({"type":"STATE", "value":{"bookmarks":{"chicken_stream":{"id": 1 }}}}))
         #will flush here after 2 records
@@ -85,9 +104,8 @@ class ActivateVersion(unittest.TestCase):
 
         self.target_stitch.consume(self.queue)
         finish_requests()
-
-        #request 2 would ordinarily complete first because the mock_out_of_order_all_200, but because
-        #request 2 contains an ACTIVATE_VERSION, it will not even be sent until request 1 completes
+        self.assertEqual(self.first_flush_error, None, self.first_flush_error)
+        self.assertEqual(self.second_flush_error, None, self.second_flush_error)
 
 
 if __name__== "__main__":

--- a/tests/gate_mocks.py
+++ b/tests/gate_mocks.py
@@ -1,3 +1,16 @@
+import asyncio
+
+def mock_unparsable_response_body_200(requests_sent):
+    class FakeResponse:
+        def __init__(self, requests_sent):
+            self.requests_sent = requests_sent
+
+        async def json(self):
+            self.status = 200
+            raise Exception("bad json response")
+
+    return FakeResponse(requests_sent)
+
 def mock_in_order_all_200(requests_sent):
     class FakeResponse:
         def __init__(self, requests_sent):

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -395,12 +395,14 @@ class AsyncPushToGate(unittest.TestCase):
         except Exception as ex:
             our_exception = ex
 
+        #the 2nd request returns immediately with a 400, triggering a TargetStitchException.
+        #at this point, it is game over and it does NOT matter when or with what status the 1st request comples
         self.assertIsNotNone(our_exception)
         self.assertTrue(isinstance(our_exception, TargetStitchException))
 
         emitted_state = self.out.getvalue().strip().split('\n')
         self.assertEqual(1, len(emitted_state))
-        self.assertEqual({'bookmarks': {'chicken_stream': {'id': 1}}}, json.loads(emitted_state[0]))
+        self.assertEqual('', emitted_state[0])
 
     # 2 requests.
     # both with state.
@@ -560,67 +562,11 @@ class StateEdgeCases(unittest.TestCase):
                           {"bookmarks":{"chicken_stream":{"id": 1 }},
                            'currently_syncing' : 'chicken_stream'})
 
-class ActivateVersion(unittest.TestCase):
-    def fake_flush_states(self, state_writer, future):
-        self.flushed_state_count = self.flushed_state_count + 1
-        if self.flushed_state_count == 1:
-            #2nd request has not begun because it contains an ActivateVersion and must wait for 1 to complete
-            self.assertEqual(1, len(target_stitch.PENDING_REQUESTS), "ActivateVersion request should not have been issues until 1st request completed")
-            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
-            self.assertEqual({'bookmarks': {'chicken_stream': {'id': 1}}}, target_stitch.PENDING_REQUESTS[0][1])
-        elif self.flushed_state_count == 2:
-            self.assertEqual(1, len(target_stitch.PENDING_REQUESTS))
-            self.assertEqual(future, target_stitch.PENDING_REQUESTS[0][0])
-            self.assertEqual(None, target_stitch.PENDING_REQUESTS[0][1])
-        else:
-            raise Exception('flushed state should only have been called twice')
-
-        self.og_flush_states(state_writer, future)
-
-    def setUp(self):
-        token = None
-
-        handler = StitchHandler(token,
-                                DEFAULT_STITCH_URL,
-                                target_stitch.DEFAULT_MAX_BATCH_BYTES,
-                                2,
-                                10)
-        self.out = io.StringIO()
-        self.target_stitch = target_stitch.TargetStitch(
-            [handler], self.out, 4000000, 2, 100000)
-        self.queue = [simplejson.dumps({"type": "SCHEMA", "stream": "chicken_stream",
-                                  "key_properties": ["my_float"],
-                                  "schema": {"type": "object",
-                                             "properties": {"my_float": {"type": "number"}}}})]
-        target_stitch.SEND_EXCEPTION = None
-        target_stitch.PENDING_REQUESTS = []
-        self.og_flush_states = StitchHandler.flush_states
-        self.flushed_state_count = 0
-        StitchHandler.flush_states = self.fake_flush_states
-
-
-    def test_activate_version_finishes_pending_requests(self):
-        target_stitch.OUR_SESSION = FakeSession(mock_out_of_order_all_200)
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "version":1, "record": {"id": 1, "name": "Mike"}}))
-        self.queue.append(json.dumps({"type":"STATE", "value":{"bookmarks":{"chicken_stream":{"id": 1 }}}}))
-        #will flush here after 2 records
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", 'version':1, "record": {"id": 2, "name": "Paul"}}))
-        self.queue.append(json.dumps({"type":"ACTIVATE_VERSION", 'stream': 'chicken_stream', 'version': 1 }))
-        #will flush here after 2 records
-
-
-        self.target_stitch.consume(self.queue)
-        finish_requests()
-
-        #request 2 would ordinarily complete first because the mock_out_of_order_all_200, but because
-        #request 2 contains an ACTIVATE_VERSION, it will not even be sent until request 1 completes
-
 
 #TODO: test for unparsable result.body. should throw stitchClientResponseError(response.status, "unable to parse response body as json")
 
 if __name__== "__main__":
-    # test1 = ActivateVersion()
     test1 = AsyncPushToGate()
     test1.setUp()
-    # test1.test_activate_version_finishes_pending_requests()
-    test1.test_unparseable_json_response()
+    test1.test_requests_out_of_order_second_errors()
+    # test1.test_requests_in_order()

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -252,8 +252,6 @@ class AsyncPushToGate(unittest.TestCase):
         except Exception as ex:
             our_exception = ex
 
-        # import pdb
-        # pdb.set_trace()
         self.assertIsNotNone(our_exception)
         self.assertTrue(isinstance(our_exception, TargetStitchException))
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -21,7 +21,7 @@ class DummyClient(object):
     def __init__(self):
         self.batches = []
 
-    def handle_batch(self, messages, schema, key_names, bookmark_names, state_writer, state):
+    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names, state_writer, state):
         self.batches.append(
             {'messages': messages,
              'schema': schema,


### PR DESCRIPTION
# Description of change
When asychronous requests are enabled, it becomes possible for later requests to finish before prior requests.  This ordering is problematic in the case of Full Table replication which is counting on the trailing ACTIVATE_VERSION message to enter the pipeline AFTER all of the relevant RECORD's have already been accepted.  

This change ensure that when a batch containing an ACTIVATE_VERSION message if flushed, the target will finish any previously issued pending requets before issuing a new request.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
