### PR TITLE
Support single records up to 20MB

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -489,10 +489,10 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_record
     if len(messages) <= 1:
         if len(serialized) < BIGBATCH_MAX_BATCH_BYTES:
             return [serialized]
-        else:
-            raise BatchTooLargeException(
+        raise BatchTooLargeException(
                 "A single record is larger than the Stitch API limit of {} Mb".format(
                     BIGBATCH_MAX_BATCH_BYTES // 1000000))
+
 
     pivot = len(messages) // 2
     l_half = serialize(messages[:pivot], schema, key_names, bookmark_names, max_bytes, max_records)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -490,8 +490,8 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_record
         if len(serialized) < BIGBATCH_MAX_BATCH_BYTES:
             return [serialized]
         raise BatchTooLargeException(
-                "A single record is larger than the Stitch API limit of {} Mb".format(
-                    BIGBATCH_MAX_BATCH_BYTES // 1000000))
+            "A single record is larger than the Stitch API limit of {} Mb".format(
+                BIGBATCH_MAX_BATCH_BYTES // 1000000))
 
 
     pivot = len(messages) // 2

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -250,9 +250,9 @@ class TestSerialize(unittest.TestCase):
         self.assertEqual(8, len(self.serialize_with_limit(385)))
 
     def test_raises_if_cant_stay_in_limit(self):
-        data = 'a' * 4000000
+        data = 'a' * 21000000
         message = RecordMessage(stream='colors', record=data)
-        with self.assertRaisesRegex(target_stitch.BatchTooLargeException, re.compile('the Stitch API limit of 4 Mb')):
+        with self.assertRaisesRegex(target_stitch.BatchTooLargeException, re.compile('the Stitch API limit of 20 Mb')):
             target_stitch.serialize([message], self.schema, self.key_names, self.bookmark_names, 4000000, target_stitch.DEFAULT_MAX_BATCH_RECORDS)
 
     def test_does_not_drop_records(self):
@@ -332,6 +332,6 @@ class TestDetermineStitchUrl(unittest.TestCase):
 
 
 if __name__== "__main__":
-    test1 = TestDetermineStitchUrl()
-    # test1.setUp()
-    test1.test_big_batch_preference()
+    test1 = TestSerialize()
+    test1.setUp()
+    test1.test_raises_if_cant_stay_in_limit()


### PR DESCRIPTION
----

# Description of change
Adds support for single records over the 4MB limit to target.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)

# Risks

# Rollback steps
 - revert this branch