### PR TITLE
Remove stitch urls from init

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -44,8 +44,6 @@ LOGGER = singer.get_logger().getChild('target_stitch')
 # We use this to store schema and key properties from SCHEMA messages
 StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_properties'])
 
-DEFAULT_STITCH_URL = 'https://api.stitchdata.com/v2/import/batch'
-BIGBATCH_STITCH_URL = 'https://api.stitchdata.com/v2/import/bigbatch'
 BIGBATCH_MAX_BATCH_BYTES = 20000000
 DEFAULT_MAX_BATCH_BYTES = 4000000
 DEFAULT_MAX_BATCH_RECORDS = 20000

--- a/tests/activate_version_tests.py
+++ b/tests/activate_version_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import target_stitch
-from target_stitch import StitchHandler, TargetStitchException, DEFAULT_STITCH_URL, finish_requests
+from target_stitch import StitchHandler, TargetStitchException, finish_requests
 import io
 import json
 import simplejson

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,7 +1,7 @@
 import unittest
 import singer
 import target_stitch
-from target_stitch import StitchHandler, TargetStitchException, DEFAULT_STITCH_URL, finish_requests
+from target_stitch import StitchHandler, TargetStitchException, finish_requests
 import io
 import os
 import json


### PR DESCRIPTION
# Description of change
```
(target) vagrant@cruderman1:/opt/code/target-stitch$ git grep DEFAULT_STITCH_URL
(target) vagrant@cruderman1:/opt/code/target-stitch$ git grep BIGBATCH_STITCH_URL
```

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
