### PR TITLE
Queue messages per-stream up to normal batch limits

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -600,6 +600,10 @@ class TargetStitch:
 
         elif isinstance(message, (singer.RecordMessage, singer.ActivateVersionMessage)):
             current_stream = message.stream
+            if self.messages[current_stream] and (
+                    message.version != self.messages[current_stream][0].version):
+                self.flush()
+
             self.messages[current_stream].append(message)
             self.buffer_size_bytes += len(line)
             if isinstance(message, singer.ActivateVersionMessage):


### PR DESCRIPTION
# Description of change
There's a situation where records can come in that would result in sequence numbers getting stamped at the same milisecond. This PR buffers records across streams to help smooth that out between flushes.

The situation is as follows, from the perspective of a database's binlog stream interleaving single records:

1. Table A receives an update (1 log message for Table A)
2. Table B gets updated via a trigger as a result (1 log message for Table B)
3. Table A gets another update (1 log message)
4. Table B gets another insert (1 log message)
5. Table A gets its final status (1 log message)

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
    - Ran through some general syncs with the validating handler
    - TODO: need to run with end to end and write automation to check it
 
# Risks
Medium, this changes how batching happens, so implied behavior may change.

# Rollback steps
 - revert this branch
