### PR TITLE
Fix/use nanosecond time for sequence numbers

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -422,7 +422,7 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
             state_writer.write("{}\n".format(line))
             state_writer.flush()
 
-def generate_sequence(message_num, max_records, use_nanoseconds=False):
+def generate_sequence(message_num, max_records):
     '''
     Generates a unique sequence number based on the current time in nanoseconds
     with a zero-padded message number based on the index of the record within the
@@ -455,13 +455,12 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_record
 
     '''
     serialized_messages = []
-    use_nanoseconds = len(messages) == 1 # To prevent collisions with single record batches
     for idx, message in enumerate(messages):
         if isinstance(message, singer.RecordMessage):
             record_message = {
                 'action': 'upsert',
                 'data': message.record,
-                'sequence': generate_sequence(idx, max_records, use_nanoseconds)
+                'sequence': generate_sequence(idx, max_records)
             }
 
             if message.time_extracted:
@@ -472,7 +471,7 @@ def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_record
         elif isinstance(message, singer.ActivateVersionMessage):
             serialized_messages.append({
                 'action': 'activate_version',
-                'sequence': generate_sequence(idx, max_records, use_nanoseconds)
+                'sequence': generate_sequence(idx, max_records)
             })
 
     body = {

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -423,16 +423,28 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
             state_writer.flush()
 
 def generate_sequence(message_num, max_records, use_nanoseconds=False):
-    '''Generates a unique sequence number based on the current time millis
-       with a zero-padded message number based on the magnitude of max_records.'''
-    sequence_base = str(int(time.time() * MILLISECOND_SEQUENCE_MULTIPLIER))
+    '''
+    Generates a unique sequence number based on the current time in nanoseconds
+    with a zero-padded message number based on the index of the record within the
+    magnitude of max_records.
+
+    COMPATIBILITY:
+    Maintains a historical width of 19 characters (with default `max_records`), in order
+    to not overflow downstream processes that depend on the width of this number.
+
+    Because of this requirement, `message_num` is modulo the difference between nanos
+    and millis to maintain 19 characters.
+    '''
+    nanosecond_sequence_base = str(int(time.time() * NANOSECOND_SEQUENCE_MULTIPLIER))
+    modulo = NANOSECOND_SEQUENCE_MULTIPLIER / MILLISECOND_SEQUENCE_MULTIPLIER
+    zfill_width_mod = len(str(NANOSECOND_SEQUENCE_MULTIPLIER)) - len(str(MILLISECOND_SEQUENCE_MULTIPLIER))
 
     # add an extra order of magnitude to account for the fact that we can
     # actually accept more than the max record count
-    fill = len(str(10 * max_records))
-    sequence_suffix = str(message_num).zfill(fill)
+    fill = len(str(10 * max_records)) - zfill_width_mod
+    sequence_suffix = str(int(message_num % modulo)).zfill(fill)
 
-    return int(sequence_base + sequence_suffix)
+    return int(nanosecond_sequence_base + sequence_suffix)
 
 def serialize(messages, schema, key_names, bookmark_names, max_bytes, max_records):
     '''Produces request bodies for Stitch.

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -340,11 +340,11 @@ class TestSequenceNumbers(unittest.TestCase):
 
     def test_generate_sequence_normal_batch(self):
         # Call with a sleep, to simulate the normal case (no ms collisions)
-        seq1 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=False)
+        seq1 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
         time.sleep(0.1)
-        seq2 = target_stitch.generate_sequence(10,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=False)
+        seq2 = target_stitch.generate_sequence(10,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
         time.sleep(0.1)
-        seq3 = target_stitch.generate_sequence(999,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=False)
+        seq3 = target_stitch.generate_sequence(999,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
         time.sleep(0.1)
 
         generated_seqs = [seq1,seq2,seq3]
@@ -358,9 +358,9 @@ class TestSequenceNumbers(unittest.TestCase):
     def test_generate_sequence_single_record_batches(self):
         # Call without sleep and same message_num to create collisions reliably
         # This is the situation where multiple single record batches get cut in succession
-        seq1 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=True)
-        seq2 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=True)
-        seq3 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=True)
+        seq1 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
+        seq2 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
+        seq3 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
 
         generated_seqs = [seq1,seq2,seq3]
 
@@ -377,7 +377,7 @@ class TestSequenceNumbers(unittest.TestCase):
         # - It should tolerate an order of magnitude greater records without repeat or extending the width
         max_batch = range(target_stitch.DEFAULT_MAX_BATCH_RECORDS * 10)
 
-        generated_seqs = [target_stitch.generate_sequence(i,target_stitch.DEFAULT_MAX_BATCH_RECORDS, use_nanoseconds=False)
+        generated_seqs = [target_stitch.generate_sequence(i,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
                           for i in max_batch]
 
         # Assert number's width for downstream

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -333,8 +333,8 @@ class TestDetermineStitchUrl(unittest.TestCase):
 
 class TestSequenceNumbers(unittest.TestCase):
     def setUp(self):
-        # NB: The algorithm at time of writing is: (str(ms_timestamp * 1000) + message_num.zfill(len(str(10*20000))))
-        # - 20000 being the DEFAULT_MAX_BATCH_RECORDS
+        # NB: This is the historical width of the sequence number integer
+        # - Generally, it's a combination of (timestamp + padded_row_index) for 19 digits
         # - This should be increased/decreased with care to prevent downstream issues
         self.STANDARD_SEQ_LENGTH = 19
 

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -390,8 +390,8 @@ class TestSequenceNumbers(unittest.TestCase):
 
     def test_generate_sequence_mixed_case(self):
         # Call with varying lengths of batches to ensure the widths mix
-        regular_batch = [(i,target_stitch.DEFAULT_MAX_BATCH_RECORDS,False) for i in range(100)]
-        single_record_batch = [(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS,True)]
+        regular_batch = [(i,target_stitch.DEFAULT_MAX_BATCH_RECORDS) for i in range(100)]
+        single_record_batch = [(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)]
 
         test_case = (single_record_batch +
                      regular_batch +


### PR DESCRIPTION
# Description of change
There are situations where batches can be structured in such a way as to be processed (asynchronously) and receive the exact same sequence number.

Example:
1. Table A receives an update (1 log message for Table A)
2. Table B gets updated via a trigger as a result (1 log message for Table B)
3. Table A gets another update (1 log message)
4. Table B gets another insert (1 log message)
5. Table A gets its final status (1 log message)

Since the target is now async, shipping coroutines to send these batches to Stitch is an extremely lightweight process, and may occur in sub-millisecond time for multiple batches. Since these records share the same index in the batch (`0` for single record batches), they result in the exact same sequence number.

## Fix Description

This PR modifies the current sequence generation logic to operate on a nanosecond precision, since even calling this function sequentially without any other code should not collide at that level.

The index logic is maintained for extra safety, though the record's index is modulo 1000 to maintain the overall width of the final sequence number.

# QA steps
 - [X] manual qa steps passing (list below)
    - Ran unit tests over this function multiple times to confirm 
 
# Risks
The platform that this logic is being run on must support nanosecond precision to work.

# Rollback steps
 - revert this branch
