### PR TITLE
Buffer messages per stream

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -600,6 +600,10 @@ class TargetStitch:
 
         elif isinstance(message, (singer.RecordMessage, singer.ActivateVersionMessage)):
             current_stream = message.stream
+            if self.messages[current_stream] and (
+                    message.version != self.messages[current_stream][0].version):
+                self.flush()
+
             self.messages[current_stream].append(message)
             self.buffer_size_bytes += len(line)
             if isinstance(message, singer.ActivateVersionMessage):

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -563,12 +563,14 @@ class TargetStitch:
 
 
     def flush(self):
-        if sum([len(ms) for ms in self.messages.values()]) > 0:
-            for stream in self.messages.keys():
+        flushed = False
+        for stream, messages in self.messages.items():
+            if len(messages) > 0:
                 self.flush_stream(stream)
+                flushed = True
         # NB> State is usually handled above but in the case there are no messages
         # we still want to ensure state is emitted.
-        elif self.state:
+        if not flushed and self.state:
             for handler in self.handlers:
                 handler.handle_state_only(self.state_writer, self.state)
             self.state = None

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -273,6 +273,9 @@ class StitchHandler: # pylint: disable=too-few-public-methods
             LOGGER.info('FLUSH early exit because of SEND_EXCEPTION: %s', pformat(SEND_EXCEPTION))
             return
 
+        # TODO THIS DOES NOT WORK HERE, WILL KILL PERFORMANCE AND NEGATE
+        # ALL TURBO BOOST REWORK THIS TO NOT REQUIRE THE REQUESTS TO HAVE
+        # FINISHED HERE
         finish_requests()
 
         # If and only if we have completed all pending requests then we

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -616,8 +616,10 @@ class TargetStitch:
 
         elif isinstance(message, (singer.RecordMessage, singer.ActivateVersionMessage)):
             current_stream = message.stream
-            if self.messages[current_stream] and (
-                    message.version != self.messages[current_stream][0].version):
+            # NB> This previously would flush on a stream change. Because
+            # we are now buffering records across streams we do not need
+            # to flush on stream change
+            if self.messages[current_stream] and (message.version != self.messages[current_stream][0].version):
                 self.flush()
 
             self.messages[current_stream].append(message)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -541,10 +541,10 @@ class TargetStitch:
 
 
 
-    def flush_stream(self, messages):
+    def flush_stream(self, stream):
         '''Send all the buffered messages to Stitch.'''
 
-        stream = messages[0].stream
+        messages = self.messages[stream]
         stream_meta = self.stream_meta[stream]
         for handler in self.handlers:
             handler.handle_batch(messages,
@@ -559,13 +559,13 @@ class TargetStitch:
         self.contains_activate_version[stream] = False
         self.state = None
         self.buffer_size_bytes = 0
+        self.messages[stream] = []
 
 
     def flush(self):
         if sum([len(ms) for ms in self.messages.values()]) > 0:
-            for messages in self.messages.values():
-                self.flush_stream(messages)
-            self.messages = {k: [] for k in self.messages.keys()}
+            for stream in self.messages.keys():
+                self.flush_stream(stream)
         # NB> State is usually handled above but in the case there are no messages
         # we still want to ensure state is emitted.
         elif self.state:

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -541,7 +541,6 @@ class TargetStitch:
     def flush(self):
         for stream, messages in self.messages.items():
             if len(messages) > 0:
-                LOGGER.info("XXXXX FLUSHING STREAM %s", stream)
                 self.flush_stream(stream)
         # NB> State is usually handled above but in the case there are no messages
         # we still want to ensure state is emitted.

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -613,7 +613,7 @@ class TargetStitch:
                 self.contains_activate_version[current_stream] = True
 
             num_bytes = self.buffer_size_bytes
-            num_messages = len(self.messages[current_stream])
+            num_messages = sum((len(messages) for messages in self.messages.values()))
             num_seconds = time.time() - self.time_last_batch_sent
 
             enough_bytes = num_bytes >= self.max_batch_bytes

--- a/tests/activate_version_tests.py
+++ b/tests/activate_version_tests.py
@@ -80,7 +80,7 @@ class ActivateVersion(unittest.TestCase):
                                   "schema": {"type": "object",
                                              "properties": {"my_float": {"type": "number"}}}})]
         target_stitch.SEND_EXCEPTION = None
-        target_stitch.PENDING_REQUESTS = []
+        target_stitch.PENDING_REQUESTS = set()
         self.og_flush_states = StitchHandler.flush_states
         self.flushed_state_count = 0
         StitchHandler.flush_states = self.fake_flush_states

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -751,8 +751,8 @@ class BufferingPerStream(unittest.TestCase):
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 1, "name": "Mike"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 2, "name": "Paul"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 3, "name": "Harrsion"}}))
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 4, "name": "Cathy"}}))
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 5, "name": "Really long name that should force the target to exceed its byte limit and flush the streams. Blah blah blah, more data more problems."}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 4, "name": "The byte limit should be across streams, so lets make lots of data on both streams"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 5, "name": "to force the target to exceed its byte limit"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 6, "name": "A"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 7, "name": "B"}}))
         # Should flush here
@@ -769,11 +769,9 @@ class BufferingPerStream(unittest.TestCase):
              {'action': 'upsert', 'data': {'id': 3, 'name': 'Harrsion'}},
              {'action': 'upsert',
               'data': {'id': 5,
-                       'name': 'Really long name that should force the target to exceed ' \
-                       'its byte limit and flush the streams. Blah blah blah, ' \
-                       'more data more problems.'}}],
+                       'name': 'to force the target to exceed its byte limit'}}],
             [{'action': 'upsert', 'data': {'id': 2, 'name': 'Paul'}},
-             {'action': 'upsert', 'data': {'id': 4, 'name': 'Cathy'}}],
+             {'action': 'upsert', 'data': {'id': 4, 'name': 'The byte limit should be across streams, so lets make lots of data on both streams'}}],
             [{'action': 'upsert', 'data': {'id': 6, 'name': 'A'}},
              {'action': 'upsert', 'data': {'id': 8, 'name': 'C'}}],
             [{'action': 'upsert', 'data': {'id': 7, 'name': 'B'}},

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -656,7 +656,7 @@ class SingleRecordBatches(unittest.TestCase):
         self.og_check_send_exception = target_stitch.check_send_exception
         self.out = io.StringIO()
         self.target_stitch = target_stitch.TargetStitch(
-            [handler], self.out, 4000000, 2, 100000)
+            [handler], self.out, 4000000, 6, 100000)
         self.queue = [json.dumps({"type": "SCHEMA", "stream": "chicken_stream",
                                   "key_properties": ["id"],
                                   "schema": {"type": "object",
@@ -705,6 +705,12 @@ class SingleRecordBatches(unittest.TestCase):
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 3, "name": "Harrsion"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 4, "name": "Cathy"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 5, "name": "Dan"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 6, "name": "A"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 7, "name": "B"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 8, "name": "C"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 9, "name": "D"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 10, "name": "E"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 11, "name": "F"}}))
         # Should only flush here
 
         self.target_stitch.consume(self.queue)
@@ -714,16 +720,28 @@ class SingleRecordBatches(unittest.TestCase):
         expected_messages = [[{'action': 'upsert',
                                'data': {'id': 2, 'name': 'Paul'}},
                               {'action': 'upsert',
-                               'data': {'id': 4, 'name': 'Cathy'}}],
+                               'data': {'id': 4, 'name': 'Cathy'}},
+                              {'action': 'upsert',
+                               'data': {'id': 6, 'name': 'A'}},
+                              {'action': 'upsert',
+                               'data': {'id': 8, 'name': 'C'}},
+                              {'action': 'upsert',
+                               'data': {'id': 10, 'name': 'E'}}],
                               [{'action': 'upsert',
                                 'data': {'id': 1, 'name': 'Mike'}},
                                {'action': 'upsert',
                                 'data': {'id': 3, 'name': 'Harrsion'}},
                                {'action': 'upsert',
-                                'data': {'id': 5, 'name': 'Dan'}}]]
+                                'data': {'id': 5, 'name': 'Dan'}},
+                               {'action': 'upsert',
+                                'data': {'id': 7, 'name': 'B'}},
+                               {'action': 'upsert',
+                                'data': {'id': 9, 'name': 'D'}},
+                               {'action': 'upsert',
+                                'data': {'id': 11, 'name': 'F'}}]]
 
         # Should be broken into only 2 batches
-        self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 2)
+        #self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 2)
 
         # Sort by length and remove sequence number to compare directly
         actual_messages = [[{key: m[key] for key in ["action","data"]} for m in ms]

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -448,8 +448,9 @@ class AsyncPushToGate(unittest.TestCase):
         self.assertTrue(isinstance(our_exception, TargetStitchException))
 
         emitted_state = self.out.getvalue().strip().split('\n')
+        expected_state = '{"bookmarks": {"chicken_stream": {"id": 1}}}'
         self.assertEqual(1, len(emitted_state))
-        self.assertEqual('', emitted_state[0])
+        self.assertEqual(expected_state, emitted_state[0])
 
     # 2 requests.
     # both with state.

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -419,22 +419,6 @@ class AsyncPushToGate(unittest.TestCase):
     # both with state.
     # out of order
     # second SENT request errors
-    def out_of_order_second_errors(self, requests_sent):
-        class FakeResponse:
-            def __init__(self, requests_sent):
-                self.requests_sent = requests_sent
-
-            async def json(self):
-                if (self.requests_sent == 1):
-                    self.status = 200
-                    await asyncio.sleep(3)
-                    return {"status" : "finished request {}".format(requests_sent)}
-
-                self.status = 400
-                return {"status" : "finished request {}".format(requests_sent)}
-
-        return FakeResponse(requests_sent)
-
     def test_requests_out_of_order_second_errors(self):
         target_stitch.OUR_SESSION = FakeSession(mock_out_of_order_second_errors)
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 1, "name": "Mike"}}))

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -656,7 +656,7 @@ class BufferingPerStream(unittest.TestCase):
         self.og_check_send_exception = target_stitch.check_send_exception
         self.out = io.StringIO()
         self.target_stitch = target_stitch.TargetStitch(
-            [handler], self.out, 4000000, 6, 100000)
+            [handler], self.out, 4000000, 20, 100000)
         self.queue = [json.dumps({"type": "SCHEMA", "stream": "chicken_stream",
                                   "key_properties": ["id"],
                                   "schema": {"type": "object",
@@ -698,7 +698,7 @@ class BufferingPerStream(unittest.TestCase):
     def test_streams_buffer_records(self):
         # Tests that the target will buffer records per stream. This will
         # allow the tap to alternate which streams it is emitting records
-        # for without the target cutting batches of 1 record
+        # for without the target cutting small batches
         target_stitch.OUR_SESSION = FakeSession(mock_in_order_all_200)
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 1, "name": "Mike"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 2, "name": "Paul"}}))

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -448,9 +448,8 @@ class AsyncPushToGate(unittest.TestCase):
         self.assertTrue(isinstance(our_exception, TargetStitchException))
 
         emitted_state = self.out.getvalue().strip().split('\n')
-        expected_state = '{"bookmarks": {"chicken_stream": {"id": 1}}}'
         self.assertEqual(1, len(emitted_state))
-        self.assertEqual(expected_state, emitted_state[0])
+        self.assertEqual('', emitted_state[0])
 
     # 2 requests.
     # both with state.

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -738,8 +738,6 @@ class BufferingPerStream(unittest.TestCase):
              {'action': 'upsert',
               'data': {'id': 7, 'name': 'B'}},]]
 
-
-
         # Should be broken into 4 batches
         self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 4)
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -656,7 +656,7 @@ class BufferingPerStream(unittest.TestCase):
         self.og_check_send_exception = target_stitch.check_send_exception
         self.out = io.StringIO()
         self.target_stitch = target_stitch.TargetStitch(
-            [handler], self.out, 4000000, 20, 100000)
+            [handler], self.out, 4000000, 7, 100000)
         self.queue = [json.dumps({"type": "SCHEMA", "stream": "chicken_stream",
                                   "key_properties": ["id"],
                                   "schema": {"type": "object",
@@ -707,41 +707,41 @@ class BufferingPerStream(unittest.TestCase):
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 5, "name": "Dan"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 6, "name": "A"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 7, "name": "B"}}))
+        # Should flush here
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 8, "name": "C"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 9, "name": "D"}}))
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 10, "name": "E"}}))
-        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 11, "name": "F"}}))
-        # Should only flush here
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 10, "name": "E"}}))
+        # Should flush here
 
         self.target_stitch.consume(self.queue)
         finish_requests()
 
-        # Sorted by length
-        expected_messages = [[{'action': 'upsert',
-                               'data': {'id': 2, 'name': 'Paul'}},
-                              {'action': 'upsert',
-                               'data': {'id': 4, 'name': 'Cathy'}},
-                              {'action': 'upsert',
-                               'data': {'id': 6, 'name': 'A'}},
-                              {'action': 'upsert',
-                               'data': {'id': 8, 'name': 'C'}},
-                              {'action': 'upsert',
-                               'data': {'id': 10, 'name': 'E'}}],
-                              [{'action': 'upsert',
-                                'data': {'id': 1, 'name': 'Mike'}},
-                               {'action': 'upsert',
-                                'data': {'id': 3, 'name': 'Harrsion'}},
-                               {'action': 'upsert',
-                                'data': {'id': 5, 'name': 'Dan'}},
-                               {'action': 'upsert',
-                                'data': {'id': 7, 'name': 'B'}},
-                               {'action': 'upsert',
-                                'data': {'id': 9, 'name': 'D'}},
-                               {'action': 'upsert',
-                                'data': {'id': 11, 'name': 'F'}}]]
+        expected_messages = [
+            [{'action': 'upsert',
+              'data': {'id': 8, 'name': 'C'}}],
+            [{'action': 'upsert',
+              'data': {'id': 9, 'name': 'D'}},
+             {'action': 'upsert',
+              'data': {'id': 10, 'name': 'E'}}],
+            [{'action': 'upsert',
+              'data': {'id': 2, 'name': 'Paul'}},
+             {'action': 'upsert',
+              'data': {'id': 4, 'name': 'Cathy'}},
+             {'action': 'upsert',
+              'data': {'id': 6, 'name': 'A'}}],
+            [{'action': 'upsert',
+              'data': {'id': 1, 'name': 'Mike'}},
+             {'action': 'upsert',
+              'data': {'id': 3, 'name': 'Harrsion'}},
+             {'action': 'upsert',
+              'data': {'id': 5, 'name': 'Dan'}},
+             {'action': 'upsert',
+              'data': {'id': 7, 'name': 'B'}},]]
 
-        # Should be broken into only 2 batches
-        self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 2)
+
+
+        # Should be broken into 4 batches
+        self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 4)
 
         # Sort by length and remove sequence number to compare directly
         actual_messages = [[{key: m[key] for key in ["action","data"]} for m in ms]

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -770,7 +770,7 @@ class BufferingPerStreamConstraints(unittest.TestCase):
              {'action': 'upsert', 'data': {'id': 3, 'name': 'Harrsion'}},
              {'action': 'upsert',
               'data': {'id': 5,
-                       'name': 'Really long name that should force the target to exceed the limit'}}],
+                       'name': 'to force the target to exceed its byte limit'}}],
             [{'action': 'upsert', 'data': {'id': 2, 'name': 'Paul'}},
              {'action': 'upsert', 'data': {'id': 4, 'name': 'The byte limit should be across streams, so lets make lots of data on both streams'}}],
             [{'action': 'upsert', 'data': {'id': 6, 'name': 'A'}},

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -697,8 +697,7 @@ class SingleRecordBatches(unittest.TestCase):
 
     def test_single_record_batches_dont_exist(self):
         # Tests that the target will not emit single record batches if
-        # streams alternate rapidly due to this increasing the chance for
-        # duplicate sequence numbers.
+        # streams alternate rapidly
         target_stitch.OUR_SESSION = FakeSession(mock_in_order_all_200)
         self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 1, "name": "Mike"}}))
         self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 2, "name": "Paul"}}))

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -22,12 +22,15 @@ class DummyClient(object):
     def __init__(self):
         self.batches = []
 
-    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names, state_writer, state):
+    def handle_batch(self, messages, contains_activate_version, schema, key_names, bookmark_names):
         self.batches.append(
             {'messages': messages,
              'schema': schema,
              'key_names': key_names,
              'bookmark_names': bookmark_names})
+
+    def handle_state(self, state_writer=None, state=None):
+        pass
 
 def message_queue(messages):
     return [json.dumps(m) for m in messages]


### PR DESCRIPTION
# Description of change
Buffer messages separately based on the stream. The target will still flush messages based on the total number of messages, but it will not flush on switching to a new stream.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)

# Risks
High - This code touches every record message emitted by the target. If there is a bug in here it would affect every tap deployed after this PR is merged.

# Rollback steps
 - revert this branch
