### PR TITLE
Fix/make sure to flush state

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -798,7 +798,7 @@ def check_send_exception():
     except StitchClientResponseError as exc:
         try:
             msg = "{}: {}".format(str(exc.status), exc.response_body)
-        except Exception as e: # pylint: disable=bare-except
+        except Exception: # pylint: disable=bare-except
             LOGGER.exception('Exception while processing error response')
             msg = '{}'.format(exc)
         raise TargetStitchException('Error persisting data to Stitch: ' +

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -802,7 +802,7 @@ def check_send_exception():
             LOGGER.exception('Exception while processing error response')
             msg = '{}'.format(exc)
         raise TargetStitchException('Error persisting data to Stitch: ' +
-                                    msg) from e
+                                    msg) from exc
 
     # A ClientConnectorErrormeans we
     # couldn't even connect to stitch. The exception is likely

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -591,21 +591,18 @@ class TargetStitch:
 
 
     def flush(self):
-        flushed = False
-
         # Have to keep track of how many streams we have looked at so we
         # know when we are flushing the final stream
+        messages_to_flush = { stream: messages for stream, messages in self.messages.items() if len(messages) > 0 }
         num_flushed = 0
-        num_streams = len(self.messages)
-        for stream, messages in self.messages.items():
+        num_streams = len(messages_to_flush)
+        for stream, messages in messages_to_flush.items():
             num_flushed += 1
-            if len(messages) > 0:
-                is_final_stream = num_flushed == num_streams
-                self.flush_stream(stream, is_final_stream)
-                flushed = True
+            is_final_stream = num_flushed == num_streams
+            self.flush_stream(stream, is_final_stream)
         # NB> State is usually handled above but in the case there are no messages
         # we still want to ensure state is emitted.
-        if not flushed and self.state:
+        if num_flushed == 0 and self.state:
             for handler in self.handlers:
                 handler.handle_state_only(self.state_writer, self.state)
             self.state = None

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -8,6 +8,7 @@ import json
 import asyncio
 import simplejson
 import collections
+import time
 from decimal import Decimal
 try:
     from tests.gate_mocks import (
@@ -884,7 +885,6 @@ class BufferingPerStreamConstraints(unittest.TestCase):
 
 class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
     def setUp(self):
-        import time
         time.sleep(20)
         self.maxDiff = None
         token = None

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1008,10 +1008,6 @@ class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
 
         expected_state = ''
 
-        # Should be broken into 2 batches (because the third fails)
-        LOGGER.info("MESSAGES SENT:")
-        LOGGER.info(target_stitch.OUR_SESSION.messages_sent)
-
         self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 2)
 
         # Sort by length and remove sequence number to compare directly

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -884,6 +884,8 @@ class BufferingPerStreamConstraints(unittest.TestCase):
 
 class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
     def setUp(self):
+        import time
+        time.sleep(20)
         self.maxDiff = None
         token = None
         handler = StitchHandler(target_stitch.DEFAULT_MAX_BATCH_BYTES, 3)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1007,6 +1007,9 @@ class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
         expected_state = ''
 
         # Should be broken into 2 batches (because the third fails)
+        LOGGER.info("MESSAGES SENT:")
+        LOGGER.info(target_stitch.OUR_SESSION.messages_sent)
+
         self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 2)
 
         # Sort by length and remove sequence number to compare directly

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -7,6 +7,7 @@ import os
 import json
 import asyncio
 import simplejson
+import collections
 from decimal import Decimal
 try:
     from tests.gate_mocks import (
@@ -809,6 +810,78 @@ class BufferingPerStreamConstraints(unittest.TestCase):
         self.assertEqual(actual_state, expected_state)
 
 
+    def test_state_works_when_streams_with_no_messages(self):
+        # Test that target_stitch will emit state messages for a stream
+        # even if the final stream in self.messages does not contain any
+        # messages
+        target_stitch.OUR_SESSION = FakeSession(mock_in_order_all_200)
+        self.target_stitch.messages = collections.OrderedDict(self.target_stitch.messages)
+
+        self.queue.append(json.dumps({
+                "type": "SCHEMA",
+                "stream": "lion_stream",
+                "key_properties": ["id"],
+                "schema": {"type": "object",
+                           "properties": {"id": {"type": "integer"},
+                                          "name": {"type": "string"}}}}))
+
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 1, "name": "Mike"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 2, "name": "Paul"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 3, "name": "Harrsion"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 4, "name": "Cathy"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 5, "name": "Dan"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 6, "name": "A"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 7, "name": "B"}}))
+        self.queue.append(json.dumps({"type": "STATE",  "value": {"bookmarks": {"chicken_stream": {"id": 7},
+                                                                                "zebra_stream": {"id": 6}}}}))
+        # Should flush here
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "zebra_stream", "record": {"id": 8, "name": "C"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 9, "name": "D"}}))
+        self.queue.append(json.dumps({"type": "RECORD", "stream": "chicken_stream", "record": {"id": 10, "name": "E"}}))
+        self.queue.append(json.dumps({"type": "STATE",  "value": {"bookmarks": {"chicken_stream": {"id": 10},
+                                                                                "zebra_stream": {"id": 8}}}}))
+        # Should flush here
+
+        self.target_stitch.consume(self.queue)
+        finish_requests()
+
+        expected_messages = [
+            [{'action': 'upsert',
+              'data': {'id': 8, 'name': 'C'}}],
+            [{'action': 'upsert',
+              'data': {'id': 9, 'name': 'D'}},
+             {'action': 'upsert',
+              'data': {'id': 10, 'name': 'E'}}],
+            [{'action': 'upsert',
+              'data': {'id': 2, 'name': 'Paul'}},
+             {'action': 'upsert',
+              'data': {'id': 4, 'name': 'Cathy'}},
+             {'action': 'upsert',
+              'data': {'id': 6, 'name': 'A'}}],
+            [{'action': 'upsert',
+              'data': {'id': 1, 'name': 'Mike'}},
+             {'action': 'upsert',
+              'data': {'id': 3, 'name': 'Harrsion'}},
+             {'action': 'upsert',
+              'data': {'id': 5, 'name': 'Dan'}},
+             {'action': 'upsert',
+              'data': {'id': 7, 'name': 'B'}},]]
+
+        expected_state = [{"bookmarks": {"zebra_stream": {"id": 8}, "chicken_stream": {"id": 10}}}]
+
+        # Should be broken into 4 batches
+        self.assertEqual(len(target_stitch.OUR_SESSION.messages_sent), 4)
+
+        # Sort by length and remove sequence number to compare directly
+        actual_messages = [[{key: m[key] for key in ["action","data"]} for m in ms]
+                           for ms in sorted(target_stitch.OUR_SESSION.messages_sent, key=lambda ms: len(ms))]
+
+        actual_state = list(map(lambda x: simplejson.loads(x, use_decimal=True), self.out.getvalue().strip().split('\n')))
+
+        self.assertEqual(actual_messages, expected_messages)
+        self.assertEqual(actual_state, expected_state)
+
+
 class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
@@ -929,7 +1002,7 @@ class BufferingPerStreamNoStateOnFailure(unittest.TestCase):
         expected_messages = [[{'action': 'upsert', 'data': {'id': 1}},
                               {'action': 'upsert', 'data': {'id': 2}}],
                              [{'action': 'upsert', 'data': {'id': 1}},
-                             {'action': 'upsert', 'data': {'id': 2}}]]
+                              {'action': 'upsert', 'data': {'id': 2}}]]
 
         expected_state = ''
 


### PR DESCRIPTION
# Description of change
Fixes a case where the state was not flushing if the final stream in `target_stitch.messages` does not have any messages.

Wrote an additional test for this case. The test failed on master and passed on this branch.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
