### PR TITLE
Log the record count

### DIFF
--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -335,6 +335,17 @@ class StitchHandler: # pylint: disable=too-few-public-methods
 
                 self.send(body, contains_activate_version, state_writer, flushable_state, stitch_url)
 
+        record_count_metric = {
+            "type": "counter",
+            "metric": "record_count",
+            "value": len([m for m in messages if isinstance(m, singer.RecordMessage)]),
+            "tags": {
+                "endpoint": messages[0].stream,
+                "num_bytes": sum([len(body) for body in bodies])
+            },
+        }
+        LOGGER.info('METRIC: %s', json.dumps(record_count_metric))
+
 
 class LoggingHandler:  # pylint: disable=too-few-public-methods
     '''Logs records to a local output file.'''


### PR DESCRIPTION
# Description of change
This PR adds a log line to the target that outputs the number of record messages it saw in a batch. It also tells you how many bytes was in the batch

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- Low, it's just a log line
- If `messages` and `bodies` are empty, then `len([])` and `sum([])` just return `0`

# Rollback steps
 - revert this branch
