### PR TITLE
Support for python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0
+  * Bump singer-python to version `6.0.0`, which adds support for python `3.10+` but is no longer compatible with python `3.5` 
+  * Bumps requests and aiohttp libraries to more secure versions [#108](https://github.com/singer-io/target-stitch/pull/108)
+
 ## 3.2.2
   * Remove unused dependencies [#107](https://github.com/singer-io/target-stitch/pull/107)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='3.2.2',
+      version='4.0.0',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',
@@ -12,11 +12,11 @@ setup(name='target-stitch',
       install_requires=[
           'jsonschema==2.6.0',
           'mock==2.0.0',
-          'requests==2.20.0',
-          'singer-python==5.8.0',
+          'requests==2.31.0',
+          'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.7.4',
+          'aiohttp==3.8.5',
 	  'ciso8601',
       ],
       extras_require={


### PR DESCRIPTION
# Description of change
Bumps singer-python version to `6.0.0`, which includes updated backoff version that is compatible with python 3.11, but drops support for python 3.5 

Includes requests and aiohttp version bumps from dependabot prs #106 and #105

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Taps still on python 3.5 will not be able to use this version of target-stitch. However, the version picked up is hardcoded in the [stitch-orchestrator dockerfile](https://github.com/stitchdata/orchestrator/blob/master/containers/Dockerfile#L19), so this will not be used until it is updated there.
# Rollback steps
 - revert this branch
