### PR TITLE
Bump aiohttp and requests to more secure versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
             source ~/.virtualenvs/target-stitch/bin/activate
             pip install -U pip setuptools
             pip install -e .[dev]
-            pip install -U pylint
       - run:
           name: 'Run tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
             source ~/.virtualenvs/target-stitch/bin/activate
             pip install -U pip setuptools
             pip install -e .[dev]
+            pip install -U pylint
       - run:
           name: 'Run tests'
           command: |
@@ -30,4 +31,4 @@ jobs:
             nosetests -v tests/activate_version_tests.py
             nosetests -v --ignore-files=activate_version_tests.py
             #nosetests
-            pylint target_stitch "--extension-pkg-whitelist=ciso8601" -d 'global-variable-not-assigned, consider-using-generator, broad-exception-raised, unused-argument'
+            pylint target_stitch "--extension-pkg-whitelist=ciso8601" --max-positional-arguments=3 -d 'global-variable-not-assigned, consider-using-generator, broad-exception-raised, unused-argument'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
             nosetests -v tests/activate_version_tests.py
             nosetests -v --ignore-files=activate_version_tests.py
             #nosetests
-            pylint target_stitch "--extension-pkg-whitelist=ciso8601" --max-positional-arguments=3 -d 'global-variable-not-assigned, consider-using-generator, broad-exception-raised, unused-argument'
+            pylint target_stitch "--extension-pkg-whitelist=ciso8601" --max-positional-arguments=8 -d 'global-variable-not-assigned, consider-using-generator, broad-exception-raised, unused-argument'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1
+  * Bump aiohttp from 3.8.5 to 3.11.9
+  * Bump requests from 2.31.0 to 3.32.3 [#112] (https://github.com/singer-io/target-stitch/pull/112)
+
 ## 4.0.0
   * Bump singer-python to version `6.0.0`, which adds support for python `3.10+` but is no longer compatible with python `3.5` 
   * Bumps requests and aiohttp libraries to more secure versions [#108](https://github.com/singer-io/target-stitch/pull/108)

--- a/setup.py
+++ b/setup.py
@@ -12,18 +12,18 @@ setup(name='target-stitch',
       install_requires=[
           'jsonschema==2.6.0',
           'mock==2.0.0',
-          'requests==2.32.0',
+          'requests==2.32.3',
           'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.10.11',
+          'aiohttp==3.11.9',
 	  'ciso8601',
       ],
       extras_require={
           'dev': [
               'nose==1.3.7',
-              'astroid==3.2.4',
-              'pylint==3.2.7'
+              'astroid==2.1.0',
+              'pylint==2.1.1'
           ]
       },
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(name='target-stitch',
           'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.8.5',
+          'aiohttp==3.10.11',
 	  'ciso8601',
       ],
       extras_require={
           'dev': [
               'nose==1.3.7',
               'astroid==2.1.0',
-              'pylint==2.1.1'
+              'pylint==3.2.7'
           ]
       },
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='target-stitch',
       extras_require={
           'dev': [
               'nose==1.3.7',
-              'astroid==2.1.0',
+              'astroid==3.2.4',
               'pylint==3.2.7'
           ]
       },

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='target-stitch',
           'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.10.11',
+          'aiohttp==3.9.5',
 	  'ciso8601',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='4.0.0',
+      version='4.0.1',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',
@@ -12,11 +12,11 @@ setup(name='target-stitch',
       install_requires=[
           'jsonschema==2.6.0',
           'mock==2.0.0',
-          'requests==2.31.0',
+          'requests==2.32.0',
           'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.9.5',
+          'aiohttp==3.10.11',
 	  'ciso8601',
       ],
       extras_require={

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -70,7 +70,7 @@ def start_loop(loop):
     asyncio.set_event_loop(loop)
     global OUR_SESSION
     timeout = aiohttp.ClientTimeout(sock_connect=60, sock_read=60)
-    OUR_SESSION = aiohttp.ClientSession(connector=aiohttp.TCPConnector(), timeout=timeout)
+    OUR_SESSION = aiohttp.ClientSession(connector=aiohttp.TCPConnector(loop=loop), timeout=timeout)
     loop.run_forever()
 
 new_loop = asyncio.new_event_loop()


### PR DESCRIPTION
# Description of change

- Bump requests from 2.31.0 to 3.32.3
- Bump aiohttp from 3.8.5 to 3.11.9
- In aiohttp version 3.8.5, the [get_event_loop](https://github.com/aio-libs/aiohttp/blob/v3.8.5/aiohttp/helpers.py#L284) method was used to retrieve the current event loop. This method would return the running event loop if one existed; otherwise, it would return the default event loop. However, in the latest versions of aiohttp, the[ get_running_loop](https://github.com/aio-libs/aiohttp/blob/v3.10.11/aiohttp/connector.py#L258) method is used instead. Unlike get_event_loop, get_running_loop raises an error if no event loop is currently running.

- In our case, we create an event loop and set it as[ the current loop for the thread](https://github.com/singer-io/target-stitch/blob/master/target_stitch/__init__.py#L69-#L83). However, since the loop is not yet in a running state, the latest aiohttp version throws an error when it tries to find a running event loop. 

```Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/code/target-stitch/target_stitch/__init__.py", line 73, in start_loop
    OUR_SESSION = aiohttp.ClientSession(connector=aiohttp.TCPConnector(), timeout=timeout)
  File "/usr/local/share/virtualenvs/target-stitch/lib/python3.8/site-packages/aiohttp/connector.py", line 851, in __init__
    super().__init__(
  File "/usr/local/share/virtualenvs/target-stitch/lib/python3.8/site-packages/aiohttp/connector.py", line 258, in __init__
    loop = loop or asyncio.get_running_loop()
RuntimeError: no running event loop
```

- To resolve this, we explicitly pass our created event loop to the [TCPConnector object](https://github.com/singer-io/target-stitch/blob/bump-aiohttp-from-3.8.5-3.10.11/target_stitch/__init__.py#L73). By doing so, aiohttp directly uses the provided event loop without attempting to locate a running loop, avoiding the error.


# QA steps
 - [x] automated tests passing
 - [x] Verified that the target emits records as expected by running tap with the orchestrator.
 - [x] Verified the logs target logs with the current version and previous version.
 - [x] Verified that the target does not break in between while processing the tap records.
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
