### PR TITLE
[113] Upgrade `aiohttp` from 3.8.5 to 3.11.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='target-stitch',
           'singer-python==6.0.0',
           'psutil==5.6.6',
           'simplejson==3.11.1',
-          'aiohttp==3.8.5',
+          'aiohttp==3.11.11',
 	  'ciso8601',
       ],
       extras_require={


### PR DESCRIPTION
https://github.com/singer-io/target-stitch/issues/113

# Description of change

Upgrading `aiohttp` from 3.8.5 to 3.11.11, so that it is compatible with Python 3.13.

# QA steps
 - [ ] automated tests passing
 - [no] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [no] this PR has been written with the help of GitHub Copilot or another generative AI tool
