### PR TITLE
SAC-28947: Fix sequence numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## 4.0.2
+  * Bump aiohttp from 3.11.9 to 3.12.14
+  * Bump requests from 2.32.3 to 2.32.4
+  * Updates `generate_sequence` to use a python monotonic clock
+  * Defines `STANDARD_SEQ_LENGTH` in the target instead of tests [#119](https://github.com/singer-io/target-stitch/pull/119)
+
 ## 4.0.1
   * Bump aiohttp from 3.8.5 to 3.11.9
-  * Bump requests from 2.31.0 to 3.32.3 [#112] (https://github.com/singer-io/target-stitch/pull/112)
+  * Bump requests from 2.31.0 to 2.32.3 [#112] (https://github.com/singer-io/target-stitch/pull/112)
 
 ## 4.0.0
-  * Bump singer-python to version `6.0.0`, which adds support for python `3.10+` but is no longer compatible with python `3.5` 
+  * Bump singer-python to version `6.0.0`, which adds support for python `3.10+` but is no longer compatible with python `3.5`
   * Bumps requests and aiohttp libraries to more secure versions [#108](https://github.com/singer-io/target-stitch/pull/108)
 
 ## 3.2.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='4.0.1',
+      version='4.0.2',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -432,7 +432,7 @@ class ValidatingHandler: # pylint: disable=too-few-public-methods
 
 def generate_sequence(message_num, max_records):
     '''
-    Generates a unique sequence number based on the current time in nanoseconds
+    Generates a unique sequence number based on a python monotonic clock in nanoseconds
     with a zero-padded message number based on the index of the record within the
     magnitude of max_records.
 
@@ -440,8 +440,8 @@ def generate_sequence(message_num, max_records):
     Maintains a historical width of 19 characters (with default `max_records`), in order
     to not overflow downstream processes that depend on the width of this number.
 
-    Because of this requirement, `message_num` is modulo the difference between nanos
-    and millis to maintain 19 characters.
+    Because of this requirement, `message_num` is modulo a number to maintain 19
+    characters.
     '''
     nanosecond_sequence_base = str(time.monotonic_ns())
     fill = STANDARD_SEQ_LENGTH - len(nanosecond_sequence_base)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -49,6 +49,11 @@ BIGBATCH_MAX_BATCH_BYTES = 20000000
 DEFAULT_MAX_BATCH_BYTES = 4000000
 DEFAULT_MAX_BATCH_RECORDS = 20000
 
+# NB: This is the historical width of the sequence number integer
+# - Generally, it's a combination of (timestamp + padded_row_index) for 19 digits
+# - This should be increased/decreased with care to prevent downstream issues
+STANDARD_SEQ_LENGTH = 19
+
 # This is our singleton aiohttp session
 OUR_SESSION = None
 
@@ -438,9 +443,9 @@ def generate_sequence(message_num, max_records):
     Because of this requirement, `message_num` is modulo the difference between nanos
     and millis to maintain 19 characters.
     '''
-    nanosecond_sequence_base = str(int(time.monotonic_ns() * 100))
-    modulo = 100
-    fill = 2
+    nanosecond_sequence_base = str(time.monotonic_ns())
+    fill = STANDARD_SEQ_LENGTH - len(nanosecond_sequence_base)
+    modulo = 10**fill
     sequence_suffix = str(int(message_num % modulo)).zfill(fill)
 
     return int(nanosecond_sequence_base + sequence_suffix)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -48,7 +48,6 @@ StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_pro
 BIGBATCH_MAX_BATCH_BYTES = 20000000
 DEFAULT_MAX_BATCH_BYTES = 4000000
 DEFAULT_MAX_BATCH_RECORDS = 20000
-MILLISECOND_SEQUENCE_MULTIPLIER = 1000
 NANOSECOND_SEQUENCE_MULTIPLIER = 1000000
 
 # This is our singleton aiohttp session
@@ -441,12 +440,6 @@ def generate_sequence(message_num, max_records):
     and millis to maintain 19 characters.
     '''
     nanosecond_sequence_base = str(int(time.time() * NANOSECOND_SEQUENCE_MULTIPLIER * 10))
-    modulo = NANOSECOND_SEQUENCE_MULTIPLIER / MILLISECOND_SEQUENCE_MULTIPLIER
-    zfill_width_mod = len(str(NANOSECOND_SEQUENCE_MULTIPLIER)) - len(str(MILLISECOND_SEQUENCE_MULTIPLIER))
-
-    # add an extra order of magnitude to account for the fact that we can
-    # actually accept more than the max record count
-    fill = len(str(10 * max_records)) - zfill_width_mod
     modulo = 100
     fill = 2
     sequence_suffix = str(int(message_num % modulo)).zfill(fill)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -48,7 +48,6 @@ StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_pro
 BIGBATCH_MAX_BATCH_BYTES = 20000000
 DEFAULT_MAX_BATCH_BYTES = 4000000
 DEFAULT_MAX_BATCH_RECORDS = 20000
-NANOSECOND_SEQUENCE_MULTIPLIER = 1000000
 
 # This is our singleton aiohttp session
 OUR_SESSION = None
@@ -439,7 +438,7 @@ def generate_sequence(message_num, max_records):
     Because of this requirement, `message_num` is modulo the difference between nanos
     and millis to maintain 19 characters.
     '''
-    nanosecond_sequence_base = str(int(time.time() * NANOSECOND_SEQUENCE_MULTIPLIER * 10))
+    nanosecond_sequence_base = str(int(time.monotonic_ns() * 100))
     modulo = 100
     fill = 2
     sequence_suffix = str(int(message_num % modulo)).zfill(fill)

--- a/target_stitch/__init__.py
+++ b/target_stitch/__init__.py
@@ -440,13 +440,15 @@ def generate_sequence(message_num, max_records):
     Because of this requirement, `message_num` is modulo the difference between nanos
     and millis to maintain 19 characters.
     '''
-    nanosecond_sequence_base = str(int(time.time() * NANOSECOND_SEQUENCE_MULTIPLIER))
+    nanosecond_sequence_base = str(int(time.time() * NANOSECOND_SEQUENCE_MULTIPLIER * 10))
     modulo = NANOSECOND_SEQUENCE_MULTIPLIER / MILLISECOND_SEQUENCE_MULTIPLIER
     zfill_width_mod = len(str(NANOSECOND_SEQUENCE_MULTIPLIER)) - len(str(MILLISECOND_SEQUENCE_MULTIPLIER))
 
     # add an extra order of magnitude to account for the fact that we can
     # actually accept more than the max record count
     fill = len(str(10 * max_records)) - zfill_width_mod
+    modulo = 100
+    fill = 2
     sequence_suffix = str(int(message_num % modulo)).zfill(fill)
 
     return int(nanosecond_sequence_base + sequence_suffix)

--- a/tests/test_target_stitch.py
+++ b/tests/test_target_stitch.py
@@ -332,12 +332,6 @@ class TestDetermineStitchUrl(unittest.TestCase):
         self.assertEqual(target_stitch.determine_stitch_url('chickens'), big_batch_url)
 
 class TestSequenceNumbers(unittest.TestCase):
-    def setUp(self):
-        # NB: This is the historical width of the sequence number integer
-        # - Generally, it's a combination of (timestamp + padded_row_index) for 19 digits
-        # - This should be increased/decreased with care to prevent downstream issues
-        self.STANDARD_SEQ_LENGTH = 19
-
     def test_generate_sequence_normal_batch(self):
         # Call with a sleep, to simulate the normal case (no ms collisions)
         seq1 = target_stitch.generate_sequence(0,target_stitch.DEFAULT_MAX_BATCH_RECORDS)
@@ -349,7 +343,7 @@ class TestSequenceNumbers(unittest.TestCase):
 
         generated_seqs = [seq1,seq2,seq3]
         # Assert number's width for downstream
-        [self.assertEqual(len(str(s)), self.STANDARD_SEQ_LENGTH) for s in generated_seqs]
+        [self.assertEqual(len(str(s)), target_stitch.STANDARD_SEQ_LENGTH) for s in generated_seqs]
         # Assert they are all at least increasing
         self.assertEqual(generated_seqs, sorted(generated_seqs))
         # Assert no collisions
@@ -365,7 +359,7 @@ class TestSequenceNumbers(unittest.TestCase):
         generated_seqs = [seq1,seq2,seq3]
 
         # Assert number's width for downstream
-        [self.assertEqual(len(str(s)), self.STANDARD_SEQ_LENGTH) for s in generated_seqs]
+        [self.assertEqual(len(str(s)), target_stitch.STANDARD_SEQ_LENGTH) for s in generated_seqs]
         # Assert they are all at least increasing
         self.assertEqual(generated_seqs, sorted(generated_seqs))
         # Assert no collisions
@@ -381,7 +375,7 @@ class TestSequenceNumbers(unittest.TestCase):
                           for i in max_batch]
 
         # Assert number's width for downstream
-        [self.assertEqual(len(str(s)), self.STANDARD_SEQ_LENGTH) for s in generated_seqs]
+        [self.assertEqual(len(str(s)), target_stitch.STANDARD_SEQ_LENGTH) for s in generated_seqs]
         # Assert they are all at least increasing
         self.assertEqual(generated_seqs, sorted(generated_seqs))
         # Assert no collisions
@@ -403,7 +397,7 @@ class TestSequenceNumbers(unittest.TestCase):
         generated_seqs = [target_stitch.generate_sequence(*values) for values in test_case]
 
         # Assert number's width for downstream
-        [self.assertEqual(len(str(s)), self.STANDARD_SEQ_LENGTH) for s in generated_seqs]
+        [self.assertEqual(len(str(s)), target_stitch.STANDARD_SEQ_LENGTH) for s in generated_seqs]
         # Assert they are all at least increasing
         self.assertEqual(generated_seqs, sorted(generated_seqs))
         # Assert no collisions


### PR DESCRIPTION
# Description of change
This PR gets `test_generate_sequence_max_batch` green again.

## Issue Overview

The issue was surfaced in #118 where it seems like bumping the python version from `3.9.X` to `3.12.Y` made loops run faster. This caused our sequence number generator spit out out-of-order sequence numbers when the test asks for a bunch of them at one time. 

A sequence number is just some timestamp value suffixed with some portion of a message index.

So the faster looping caused two separate calls to `generate_sequence()` to happen in the same microsecond. And we use the modulo operator to create the suffix in the sequence number, so when that modulo wraps around, two consecutive sequence numbers can look out of order.

## Details

The test failed because we pretend to have a batch of 20,000 messages that need a sequence number. A handful of these message indices look like `1999, 2000`, `2999, 3000`, ... `18999, 19999`. The computed modulo value was a constant `1000` (which comes from the orders of magnitude difference between milliseconds and microseconds). This reduces all of these indices into `999` and `000`.

If the target happened to process these index pairs in the same microsecond, the beginning of the sequence number looks the same, for example `1757601874828157`. So then we produce two sequence numbers: `1757601874828157999` and `1757601874828157000`. But this is out of order because 1757601874828157999 is greater than 1757601874828157000.

Here are some diagrams to maybe help show how all of this works:
```
        ┌──────────── sequence_base, using time.time()
        │         ┌── sequence_suffix
  ┌─────┴─────┐┌──┴─┐
  1757601190613001999
```
The above is what the `generate_sequence()` function spit out in the first version of this function: https://github.com/singer-io/target-stitch/commit/0a26e3b276b941df85f12150dfece4f1db73d5eb

```
         ┌─────────── sequence_base, using time.time()
         │         ┌─ sequence_suffix
  ┌──────┴───────┐┌┴┐
  1757601874828157222
```
Above this is what the function evolved to in this commit: https://github.com/singer-io/target-stitch/commit/c73202a7a641c5d3ed0e35ebf50ed271054f7eaf

```
         ┌─────────── sequence_base, using time.time()
         │          ┌ sequence_suffix
  ┌──────┴────────┐┌┤
  1757602023085575833
```
Here is the number from the first commit in this PR: https://github.com/singer-io/target-stitch/commit/9c3f913a31c87754b6b7677ed19390bdd75051b0

```
         ┌─────────── sequence_base, using time.monotonic_ns()
         │          ┌ sequence_suffix
  ┌──────┴──────┐┌──┤
  1721449881644840032
```

And finally, this is what they look like after this PR. I think the difference between the last two implementations are that `time.time()` () does not guarantee us true nanosecond precision. 

This can be seen by calling `time.time()` and just multiplying it by bigger and bigger numbers.

```python
>>> [ int(time.time() * 10**i) for i in range(20) ]
[1757611295,            # <- This is a second timestamp
 17576112954,
 175761129541,
 1757611295410,
 17576112954103,
 175761129541034,
 1757611295410346,      # <- This is a microsecond timestamp
 17576112954103468,
 175761129541034688,
 1757611295410347264,   # <- This is a nanosecond timestamp
 17576112954103476224,
 175761129541034967040,
 1757611295410350456832,
 17576112954103509811200,
 175761129541035156832256,
 1757611295410352642064384,
 17576112954103532863094784,
 175761129541035401645391872,
 1757611295410354566209732608,
 17576112954103551159655464960]
```

Compare this to `time.monotonic_ns()`
```python
>>> [int(time.monotonic_ns() * 10**i) for i in range(20)]
[181514605205596,   # <- This is a nanosecond timestamp
 1815146052091380,
 18151460521034900,
 181514605211013000,
 1815146052114780000,
 18151460521209600000,
 181514605212603000000,
 1815146052131780000000,
 18151460521357200000000,
 181514605214011000000000,
 1815146052143740000000000,
 18151460521497500000000000,
 181514605215817000000000000,
 1815146052162170000000000000,
 18151460521701900000000000000,
 181514605217359000000000000000,
 1815146052178860000000000000000,
 18151460521834700000000000000000,
 181514605218990000000000000000000,
 1815146052193150000000000000000000]
```

We don't get random junk after the nanosecond decimal place when we use `time.monotonic_ns()`. Which means we know that function should always return 15 digits of never-decreasing numbers.

## Notes

Microsecond is not a typo above, despite the old code referencing nanoseconds. I tested this by parsing the timestamps back to date time values via `numpy`'s `datetime64` function:

```python
>>> import numpy as np
>>> import time

# Trying to parse this as (n)ano(s)econds yields a nonsensical value
>>> np.datetime64(int(time.time() * 1_000_000), 'ns')
np.datetime64('1970-01-21T08:13:25.690144291')

# Using (μ)microseconds (10^6) works
>>> np.datetime64(int(time.time() * 1_000_000), 'us')
np.datetime64('2025-09-11T15:48:14.230041')
```
[Numpy Docs](https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units)

## Other approaches
While converting to a monotonic clock seems like the correct move, you may be wondering if `time.time()` has a `time.time_ns()` cousin we could use. It does. However, given that `time.monotonic_ns()` does basically the same thing and guarantees that the values it produces cannot go backwards, I think we've landed on the better approach.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
