### PR TITLE
Bump target-stitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.0.4
   * Bump aiohttp from 3.13.3 to 3.13.4 [#124](https://github.com/singer-io/target-stitch/pull/124)
+  * Bump requests from 2.32.4 to 2.33.0 [#123](https://github.com/singer-io/target-stitch/pull/123)
 
 ## 4.0.3
   * Bump aiohttp from 3.12.14 to 3.13.3 [#121](https://github.com/singer-io/target-stitch/pull/121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.4
+  * Bump aiohttp from 3.13.3 to 3.13.4 [#124](https://github.com/singer-io/target-stitch/pull/124)
+
 ## 4.0.3
   * Bump aiohttp from 3.12.14 to 3.13.3 [#121](https://github.com/singer-io/target-stitch/pull/121)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='target-stitch',
-      version='4.0.3',
+      version='4.0.4',
       description='Singer.io target for the Stitch API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Bump target-stitch for below dependabot issue fix:
- aiohttp from 3.13.3 to 3.13.4 [#124](https://github.com/singer-io/target-stitch/pull/124)
- requests from 2.32.4 to 2.33.0 [#123](https://github.com/singer-io/target-stitch/pull/123)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
